### PR TITLE
Stop talking before skipping forward or backward.

### DIFF
--- a/ResearchUI/ResearchUI/iOS/RSDStepViewController.swift
+++ b/ResearchUI/ResearchUI/iOS/RSDStepViewController.swift
@@ -630,6 +630,7 @@ open class RSDStepViewController : UIViewController, RSDStepViewControllerProtoc
     /// which requires custom navigation because the step has not "ended" normally. For example, this method
     /// is called when a user taps the "skip" button.
     open func jumpForward() {
+        RSDSpeechSynthesizer.shared.stopTalking()
         stop()
         self.taskController.goForward()
     }


### PR DESCRIPTION
Discovered this while fixing the navigation for the "Walk and Balance" test. If you navigate away from a step due to a skip action then stop the Siri voice command. Otherwise, it is kind of confusing.