### PR TITLE
Only tag and bump the build on stable.

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -12,12 +12,12 @@ elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" == "master" ]]; then  # non-tag com
     bundle exec fastlane ci_archive scheme:"RSDTest" export_method:"app-store"
     bundle exec fastlane build scheme:"ResearchUI (watchOS)"
     bundle exec fastlane build scheme:"Research (tvOS)"
-    bundle exec fastlane bump_all
 elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" =~ ^stable-.* ]]; then # non-tag commits to stable branches
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test scheme:"RSDCatalog"
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test scheme:"RSDTest"
     bundle exec fastlane keychains
     bundle exec fastlane beta scheme:"RSDCatalog" export_method:"app-store" project:"RSDCatalog/RSDCatalog.xcodeproj"
     bundle exec fastlane beta scheme:"RSDTest" export_method:"app-store" project:"RSDTest/RSDTest.xcodeproj"
+    bundle exec fastlane bump_all
 fi
 exit $?


### PR DESCRIPTION
So... yeah. Stable won't archive and build b/c the commits are tagged by travis Fastlane so can't have **both** master and stable pushing commit tags.  Changing to **only** bump the build numbers when pushing to stable.