### PR TITLE
Refactor data tracking management.

### DIFF
--- a/Research/Research/RSDStepNavigator.swift
+++ b/Research/Research/RSDStepNavigator.swift
@@ -132,3 +132,16 @@ public protocol RSDCopyStepNavigator : RSDStepNavigator {
     /// - returns: A copy of this navigator with the inserted section.
     func copyAndInsert(_ subtask: RSDTaskInfoStep) -> Self
 }
+
+/// The tracking delegate is any class object that can be referenced using a `weak` reference.
+public protocol RSDTrackingDelegate : class {
+}
+
+/// The tracking step navigator is a step navigator that tracks user selection across different runs of a
+/// task.
+public protocol RSDTrackingStepNavigator : RSDStepNavigator {
+    
+    /// Set up tracking for this instance of a step navigator using the given task path.
+    func setupTracking(with taskPath: RSDTaskPath)
+}
+


### PR DESCRIPTION
Refactor data tracking to allow for using a tracking delegate with a weak pointer. This allows setting any class object as the delegate that a step navigator can query during set up of the task path.