### PR TITLE
Ui bug fixes 2

### DIFF
--- a/Research/Research/RSDChoicePickerTableItemGroup.swift
+++ b/Research/Research/RSDChoicePickerTableItemGroup.swift
@@ -192,4 +192,15 @@ public final class RSDBooleanTableItemGroup : RSDChoicePickerTableItemGroup {
         }
         try super.setAnswer(from: result)
     }
+    
+    /// Override to set the default answer to false if the checkbox is not checked.
+    public override func setDefaultAnswerIfValid() -> Bool {
+        if singleCheckbox && (self.answer is NSNull) {
+            try? super.setAnswer(false)
+            return true
+        }
+        else {
+            return false
+        }
+    }
 }

--- a/Research/Research/RSDInputFieldObject.swift
+++ b/Research/Research/RSDInputFieldObject.swift
@@ -69,7 +69,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, RSDMutableInputField, RSDC
     open var range: RSDRange?
     
     /// A Boolean value indicating whether the user can skip the input field without providing an answer.
-    open var isOptional: Bool = false
+    open var isOptional: Bool = true
     
     /// A list of survey rules associated with this input field.
     open var surveyRules: [RSDSurveyRule]?

--- a/Research/Research/RSDInputFieldTableItemGroup.swift
+++ b/Research/Research/RSDInputFieldTableItemGroup.swift
@@ -105,6 +105,28 @@ open class RSDInputFieldTableItemGroup : RSDTableItemGroup {
         try textItem.setAnswer(newValue)
     }
     
+    /// Set the default answer for the item group. The base class implementation does nothing.
+    /// - returns: `true` if the answer was updated and `false` if the answer was unchanged.
+    open func setDefaultAnswerIfValid() -> Bool {
+        // At this level, only the "date" has a default value.
+        guard self.items.count == 1,
+            let textItem = self.items.first as? RSDTextInputTableItem,
+            textItem.answer == nil,
+            let defaultDate = (textItem.pickerSource as? RSDDatePickerDataSource)?.defaultDate
+            else {
+                return false
+        }
+        
+        do {
+            try textItem.setAnswer(defaultDate)
+            return true
+        }
+        catch let err {
+            debugPrint("Failed to set the default answer: \(err)")
+            return false
+        }
+    }
+    
     /// Set the new answer value from a previous result. This will throw an error if the result isn't valid.
     /// Otherwise, it will set the answer.
     /// - parameter result: The result that *may* have a previous answer.

--- a/Research/Research/RSDTableItemGroup.swift
+++ b/Research/Research/RSDTableItemGroup.swift
@@ -51,7 +51,7 @@ open class RSDTableItemGroup {
     
     /// Determine if the current answer is valid. Also checks the case where answer is required but one has not
     /// been provided.
-    public var isAnswerValid: Bool {
+    open var isAnswerValid: Bool {
         return true
     }
     


### PR DESCRIPTION
Change the default for `isOptional` to `true`. Devs keep making this assumption so let's just support it as the default.

Refactor the item group to look for a default answer for the types that support it. Note: this does not **add** a default answer field for things that don't already support it (which currently is just the boolean checkbox and date picker).