### PR TITLE
Change the `nextStepIdentifier` to immutable to avoid misuse

### DIFF
--- a/Research/Research/RSDActiveUIStepObject.swift
+++ b/Research/Research/RSDActiveUIStepObject.swift
@@ -156,6 +156,16 @@ open class RSDActiveUIStepObject : RSDUIStepObject, RSDActiveUIStep {
         super.init(identifier: identifier, type: type ?? .active)
     }
     
+    /// Initializer for setting the immutable next step identifier.
+    ///
+    /// - parameters:
+    ///     - identifier: A short string that uniquely identifies the step.
+    ///     - nextStepIdentifier: The next step to jump to. This is used where direct navigation is required.
+    ///     - type: The type of the step. Default = `RSDStepType.instruction`
+    public override init(identifier: String, nextStepIdentifier: String?, type: RSDStepType? = nil) {
+        super.init(identifier: identifier, nextStepIdentifier: nextStepIdentifier, type: type)
+    }
+    
     /// Override to set the properties of the subclass.
     override open func copyInto(_ copy: RSDUIStepObject) {
         super.copyInto(copy)

--- a/Research/Research/RSDUIStepObject.swift
+++ b/Research/Research/RSDUIStepObject.swift
@@ -98,7 +98,17 @@ open class RSDUIStepObject : RSDUIActionHandlerObject, RSDThemedUIStep, RSDTable
     /// task to display information or a question on an alternate path and then exit the task. In that case,
     /// the main branch of navigation will need to "jump" over the alternate path step and the alternate path
     /// step will need to "jump" to the "exit".
-    open var nextStepIdentifier: String?
+    ///
+    /// This step is not intended for "optional" navigation where the result might change the intended
+    /// navigation. For the case where a user action might result in a different navigation path, you can
+    /// have the step controller set the step result to a result that implements `RSDNavigationResult` and
+    /// then set the `skipToIdentifier` on that result. `RSDResultObject` and `RSDCollectionResultObject`
+    /// both implement this protocol. The reason for doing this is that each time a step is visited in a
+    /// a navigation path, the **result** of that step is replaced with an immutable result and will **not**
+    /// use the previous result navigation unless specifically set by the step controller.
+    ///
+    /// - seealso: `RSDStepViewController.assignSkipToIdentifier()`
+    open private(set) var nextStepIdentifier: String?
     
     /// The navigation cohort rules to apply *before* displaying the step.
     public var beforeCohortRules: [RSDCohortNavigationRule]?
@@ -113,6 +123,21 @@ open class RSDUIStepObject : RSDUIActionHandlerObject, RSDThemedUIStep, RSDTable
     public required init(identifier: String, type: RSDStepType? = nil) {
         self.identifier = identifier
         self.stepType = type ?? .instruction
+        self._initCompleted = false
+        super.init()
+        self._initCompleted = true
+    }
+    
+    /// Initializer for setting the immutable next step identifier.
+    ///
+    /// - parameters:
+    ///     - identifier: A short string that uniquely identifies the step.
+    ///     - nextStepIdentifier: The next step to jump to. This is used where direct navigation is required.
+    ///     - type: The type of the step. Default = `RSDStepType.instruction`
+    public init(identifier: String, nextStepIdentifier: String?, type: RSDStepType? = nil) {
+        self.identifier = identifier
+        self.stepType = type ?? .instruction
+        self.nextStepIdentifier = nextStepIdentifier
         self._initCompleted = false
         super.init()
         self._initCompleted = true

--- a/Research/ResearchTests/ModelObject Tests/StepTests.swift
+++ b/Research/ResearchTests/ModelObject Tests/StepTests.swift
@@ -49,7 +49,7 @@ class StepTests: XCTestCase {
     // MARK: `copy(with:)`
     
     func testCopy_ActiveUIStepObject() {
-        let step = RSDActiveUIStepObject(identifier: "foo", type: "boo")
+        let step = RSDActiveUIStepObject(identifier: "foo", nextStepIdentifier: "bar", type: "boo")
         step.title = "title"
         step.text = "text"
         step.detail = "detail"
@@ -57,7 +57,6 @@ class StepTests: XCTestCase {
         step.viewTheme = RSDViewThemeElementObject(viewIdentifier: "fooView")
         step.colorTheme = RSDColorThemeElementObject(backgroundColorName: "fooBlue")
         step.imageTheme = RSDFetchableImageThemeElementObject(imageName: "fooIcon")
-        step.nextStepIdentifier = "bar"
         step.actions = [.navigation(.learnMore) : RSDWebViewUIActionObject(url: "fooFile", buttonTitle: "tap foo")]
         step.shouldHideActions = [.navigation(.skip)]
         step.duration = 5
@@ -119,7 +118,6 @@ class StepTests: XCTestCase {
         step.viewTheme = RSDViewThemeElementObject(viewIdentifier: "fooView")
         step.colorTheme = RSDColorThemeElementObject(backgroundColorName: "fooBlue")
         step.imageTheme = RSDFetchableImageThemeElementObject(imageName: "fooIcon")
-        step.nextStepIdentifier = "bar"
         step.actions = [.navigation(.learnMore) : RSDWebViewUIActionObject(url: "fooFile", buttonTitle: "tap foo")]
         step.shouldHideActions = [.navigation(.skip)]
         
@@ -133,7 +131,6 @@ class StepTests: XCTestCase {
         XCTAssertEqual(copy.viewTheme?.viewIdentifier, "fooView")
         XCTAssertEqual((copy.colorTheme as? RSDColorThemeElementObject)?._backgroundColorName, "fooBlue")
         XCTAssertEqual((copy.imageTheme as? RSDFetchableImageThemeElementObject)?.imageName, "fooIcon")
-        XCTAssertEqual(copy.nextStepIdentifier, "bar")
         if let learnAction = copy.actions?[.navigation(.learnMore)] as? RSDWebViewUIActionObject {
             XCTAssertEqual(learnAction.url, "fooFile")
             XCTAssertEqual(learnAction.buttonTitle, "tap foo")
@@ -172,7 +169,7 @@ class StepTests: XCTestCase {
     }
     
     func testCopy_UIStepObject() {
-        let step = RSDUIStepObject(identifier: "foo", type: "boo")
+        let step = RSDUIStepObject(identifier: "foo", nextStepIdentifier: "bar", type: "boo")
         step.title = "title"
         step.text = "text"
         step.detail = "detail"
@@ -180,7 +177,6 @@ class StepTests: XCTestCase {
         step.viewTheme = RSDViewThemeElementObject(viewIdentifier: "fooView")
         step.colorTheme = RSDColorThemeElementObject(backgroundColorName: "fooBlue")
         step.imageTheme = RSDFetchableImageThemeElementObject(imageName: "fooIcon")
-        step.nextStepIdentifier = "bar"
         step.actions = [.navigation(.learnMore) : RSDWebViewUIActionObject(url: "fooFile", buttonTitle: "tap foo")]
         step.shouldHideActions = [.navigation(.skip)]
         


### PR DESCRIPTION
The steps in a task are intended to be immutable once the task has started so that the task can run without having to put in work-arounds for task navigation which may revisit the step either because of a navigation loop or because of “backward” navigation.

However, I am seeing this property being used in violation of that expectation. Since `RSDUIStepObject` is a class and not a struct, properties that are get/set will mutate the step rather than creating a new copy of the object. Unfortunately, because structs do not support inheritance, that makes this step as a **class** particularily useful (b/c it handles a lot of deserialization logic for you). While this isn’t an issue with the other properties, because the `nextStepIdentifier` will affect navigation, it should **only** be set during initialization.

