### PR TITLE
Fix cohort skip navigation

### DIFF
--- a/Research/Research/RSDConditionalStepNavigator.swift
+++ b/Research/Research/RSDConditionalStepNavigator.swift
@@ -278,9 +278,9 @@ extension RSDConditionalStepNavigator {
             shouldSkip = false
             if let nextId = _checkConditionalSkipRules(before: returnStep, with: result, isPeeking: isPeeking) {
                 if nextId == RSDIdentifier.nextStep {
-                    shouldSkip = true
+                    returnStep = steps.rsd_next(after: {$0.identifier == returnStep?.identifier})
                 } else {
-                    returnStep = steps.rsd_next(after: {$0.identifier == nextId})
+                    returnStep = steps.first(where: {$0.identifier == nextId})
                 }
             }
             if !shouldSkip, (returnStep != nil), let navigationSkipStep = returnStep as? RSDNavigationSkipRule {

--- a/Research/ResearchTests/Navigation Tests/TaskControllerTests.swift
+++ b/Research/ResearchTests/Navigation Tests/TaskControllerTests.swift
@@ -446,4 +446,46 @@ class TaskControllerTests: XCTestCase {
         XCTAssertNotNil(directionThird)
         XCTAssertEqual(directionThird, .forward)
     }
+    
+    func testCohortNavigation_SkipFirstStep() {
+        let step1 = RSDUIStepObject(identifier: "step1")
+        let step2 = RSDUIStepObject(identifier: "step2")
+        
+        let trackingRule = TestTrackingRule(skipTo: ["step1" : "step2"], next: [:], nextAfterNil: nil)
+        RSDFactory.shared.trackingRules = [trackingRule]
+        
+        var taskResult: RSDTaskResult = RSDTaskResultObject(identifier: "test")
+        let navigator = RSDConditionalStepNavigatorObject(with: [step1, step2])
+        let nextStep = navigator.step(after: nil, with: &taskResult)
+        XCTAssertEqual(nextStep.step?.identifier, "step2")
+        XCTAssertEqual(nextStep.direction, .forward)
+        
+        RSDFactory.shared.trackingRules = []
+    }
+}
+
+class TestTrackingRule : RSDTrackingRule {
+    
+    let skipTo: [String : String]
+    let nextAfterNil: String?
+    let next: [String : String]
+    
+    init(skipTo: [String : String], next: [String : String], nextAfterNil: String?) {
+        self.skipTo = skipTo
+        self.next = next
+        self.nextAfterNil = nextAfterNil
+    }
+    
+    func skipToStepIdentifier(before step: RSDStep, with result: RSDTaskResult?, isPeeking: Bool) -> String? {
+        return skipTo[step.identifier]
+    }
+    
+    func nextStepIdentifier(after step: RSDStep?, with result: RSDTaskResult?, isPeeking: Bool) -> String? {
+        if let identifier = step?.identifier {
+            return next[identifier]
+        }
+        else {
+            return nextAfterNil
+        }
+    }
 }


### PR DESCRIPTION
Found an issue where the navigation was not correct for the case where the conditional step navigator was checking the “before” rules for a step to skip to.

This is used in the mPower Motivation survey navigation to show one of 4 possible steps.