### PR TITLE
Strip out boilerplate code that isn’t required for Swift 4.2

### DIFF
--- a/Research/Research/RSDActiveUIStepObject.swift
+++ b/Research/Research/RSDActiveUIStepObject.swift
@@ -38,7 +38,7 @@ import Foundation
 /// the `RSDActiveUIStep` protocol to allow for spoken instruction.
 open class RSDActiveUIStepObject : RSDUIStepObject, RSDActiveUIStep {
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case duration, commands, requiresBackgroundAudio, spokenInstructions
     }
 
@@ -259,32 +259,9 @@ open class RSDActiveUIStepObject : RSDUIStepObject, RSDActiveUIStep {
     
     override class func codingKeys() -> [CodingKey] {
         var keys = super.codingKeys()
-        let thisKeys: [CodingKey] = allCodingKeys()
+        let thisKeys: [CodingKey] = CodingKeys.allCases
         keys.append(contentsOf: thisKeys)
         return keys
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.duration, .commands, .requiresBackgroundAudio, .spokenInstructions]
-        return codingKeys
-    }
-    
-    override class func validateAllKeysIncluded() -> Bool {
-        guard super.validateAllKeysIncluded() else { return false }
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .duration:
-                if idx != 0 { return false }
-            case .commands:
-                if idx != 1 { return false }
-            case .requiresBackgroundAudio:
-                if idx != 2 { return false }
-            case .spokenInstructions:
-                if idx != 3 { return false }
-            }
-        }
-        return keys.count == 4
     }
 
     override class func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDAnswerResultObject.swift
+++ b/Research/Research/RSDAnswerResultObject.swift
@@ -66,7 +66,7 @@ public struct RSDAnswerResultObject : RSDAnswerResult, Codable {
         self.type = .answer
     }
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, type, startDate, endDate, answerType, value
     }
     
@@ -109,33 +109,7 @@ public struct RSDAnswerResultObject : RSDAnswerResult, Codable {
 extension RSDAnswerResultObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .type, .startDate, .endDate, .answerType, .value]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .type:
-                if idx != 1 { return false }
-            case .startDate:
-                if idx != 2 { return false }
-            case .endDate:
-                if idx != 3 { return false }
-            case .answerType:
-                if idx != 4 { return false }
-            case .value:
-                if idx != 5 { return false }
-            }
-        }
-        return keys.count == 6
+        return CodingKeys.allCases
     }
     
     static func answerResultExamples() -> [RSDAnswerResultObject] {

--- a/Research/Research/RSDAnswerResultType.swift
+++ b/Research/Research/RSDAnswerResultType.swift
@@ -41,9 +41,9 @@ import Foundation
 ///
 /// - seealso: `RSDAnswerResult` and `RSDFormDataType`
 ///
-public struct RSDAnswerResultType : Codable {
+public struct RSDAnswerResultType : Codable, Hashable, Equatable {
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case baseType, sequenceType, formDataType, dateFormat, dateLocaleIdentifier, unit, sequenceSeparator
     }
     
@@ -66,11 +66,6 @@ public struct RSDAnswerResultType : Codable {
         case string
         /// Codable
         case codable
-        
-        /// List of all the base types
-        public static var all: Set<BaseType> {
-            return [.boolean, .data, .date, .decimal, .integer, .string, .codable]
-        }
     }
     
     /// The sequence type of the answer result. This is used to represent a multiple-choice
@@ -82,11 +77,6 @@ public struct RSDAnswerResultType : Codable {
         
         /// Dictionary
         case dictionary
-        
-        /// List of all the sequence types
-        public static  var all: Set<SequenceType> {
-            return [.array, .dictionary]
-        }
     }
     
     /// The base type for the answer.
@@ -163,21 +153,9 @@ public struct RSDAnswerResultType : Codable {
     
     /// Static type for a `RSDAnswerResultType` with a `Codable` base type.
     public static let codable = RSDAnswerResultType(baseType: .codable)
-}
 
-// MARK: Equatable and Hashable
-extension RSDAnswerResultType : Hashable, Equatable {
-    
     public var description: String {
         return "\(baseType)|\(String(describing:sequenceType))|\(String(describing:dateFormat))|\(String(describing:unit))|\(String(describing:sequenceSeparator))"
-    }
-    
-    public var hashValue: Int {
-        return description.hashValue
-    }
-    
-    public static func ==(lhs: RSDAnswerResultType, rhs: RSDAnswerResultType) -> Bool {
-        return lhs.description == rhs.description
     }
 }
 
@@ -193,34 +171,7 @@ extension RSDAnswerResultType.SequenceType : RSDDocumentableStringEnum {
 extension RSDAnswerResultType : RSDDocumentableCodableObject {
 
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        return [.baseType, .sequenceType, .formDataType, .dateFormat, .dateLocaleIdentifier, .unit, .sequenceSeparator]
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .baseType:
-                if idx != 0 { return false }
-            case .sequenceType:
-                if idx != 1 { return false }
-            case .formDataType:
-                if idx != 2 { return false }
-            case .dateFormat:
-                if idx != 3 { return false }
-            case .dateLocaleIdentifier:
-                if idx != 4 { return false }
-            case .unit:
-                if idx != 5 { return false }
-            case .sequenceSeparator:
-                if idx != 6 { return false }
-            }
-        }
-        return keys.count == 7
+        return CodingKeys.allCases
     }
     
     static func examples() -> [Encodable] {
@@ -231,10 +182,10 @@ extension RSDAnswerResultType : RSDDocumentableCodableObject {
     static func examplesWithValues() -> [(answerType: RSDAnswerResultType, value: Any)] {
         var examples: [(RSDAnswerResultType, Any)] = []
 
-        let sequenceTypes = SequenceType.all
+        let sequenceTypes = SequenceType.allCases
         
         func addExamples(sequenceType: SequenceType?) {
-            let baseTypes = BaseType.all
+            let baseTypes = BaseType.allCases
             for baseType in baseTypes {
                 switch baseType {
                 case .boolean:

--- a/Research/Research/RSDAsyncActionType.swift
+++ b/Research/Research/RSDAsyncActionType.swift
@@ -37,7 +37,7 @@ import Foundation
 /// using an instance of `RSDFactory`.
 ///
 /// - seealso: `RSDAsyncActionConfiguration`
-public struct RSDAsyncActionType : RSDFactoryTypeRepresentable, Codable {
+public struct RSDAsyncActionType : RSDFactoryTypeRepresentable, Codable, Hashable {
     public let rawValue: String
     
     public init(rawValue: String) {
@@ -55,27 +55,7 @@ public struct RSDAsyncActionType : RSDFactoryTypeRepresentable, Codable {
     }
 }
 
-extension RSDAsyncActionType : Equatable {
-    public static func ==(lhs: RSDAsyncActionType, rhs: RSDAsyncActionType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-    public static func ==(lhs: String, rhs: RSDAsyncActionType) -> Bool {
-        return lhs == rhs.rawValue
-    }
-    public static func ==(lhs: RSDAsyncActionType, rhs: String) -> Bool {
-        return lhs.rawValue == rhs
-    }
-}
-
-extension RSDAsyncActionType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
-extension RSDAsyncActionType : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
+extension RSDAsyncActionType : ExpressibleByStringLiteral {    
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDChoiceInputFieldObject.swift
+++ b/Research/Research/RSDChoiceInputFieldObject.swift
@@ -37,7 +37,7 @@ import Foundation
 /// to include a list of choices for a multiple choice or single choice input field.
 open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case choices, defaultAnswer
     }
     
@@ -258,28 +258,9 @@ open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
     
     override class func codingKeys() -> [CodingKey] {
         var keys = super.codingKeys()
-        let thisKeys: [CodingKey] = allCodingKeys()
+        let thisKeys: [CodingKey] = CodingKeys.allCases
         keys.append(contentsOf: thisKeys)
         return keys
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.choices, .defaultAnswer]
-        return codingKeys
-    }
-    
-    override class func validateAllKeysIncluded() -> Bool {
-        guard super.validateAllKeysIncluded() else { return false }
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .choices:
-                if idx != 0 { return false }
-            case .defaultAnswer:
-                if idx != 1 { return false }
-            }
-        }
-        return keys.count == 2
     }
     
     override class func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDChoiceObject.swift
+++ b/Research/Research/RSDChoiceObject.swift
@@ -93,7 +93,7 @@ public struct RSDChoiceObject<T : Codable> : RSDChoice, RSDComparable, RSDEmbedd
     
     // MARK: Codable
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case value, text, detail, icon, isExclusive
     }
 
@@ -160,31 +160,7 @@ public struct RSDChoiceObject<T : Codable> : RSDChoice, RSDComparable, RSDEmbedd
 extension RSDChoiceObject : RSDDocumentableDecodableObject {
 
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.value, .text, .detail, .icon, .isExclusive]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .value:
-                if idx != 0 { return false }
-            case .text:
-                if idx != 1 { return false }
-            case .detail:
-                if idx != 2 { return false }
-            case .icon:
-                if idx != 3 { return false }
-            case .isExclusive:
-                if idx != 4 { return false }
-            }
-        }
-        return keys.count == 5
+        return CodingKeys.allCases
     }
     
     static func exampleDictionary() -> [String : RSDJSONValue]? {

--- a/Research/Research/RSDCohortTrackingRule.swift
+++ b/Research/Research/RSDCohortTrackingRule.swift
@@ -117,7 +117,7 @@ public struct RSDCohortNavigationRuleObject : RSDCohortNavigationRule, Codable {
     /// The identifier for the string to skip to.
     public let skipToIdentifier: String?
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case requiredCohorts, cohortOperator = "operator", skipToIdentifier
     }
     
@@ -146,27 +146,7 @@ extension RSDCohortRuleOperator : RSDDocumentableStringEnum {
 extension RSDCohortNavigationRuleObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.requiredCohorts, .cohortOperator, .skipToIdentifier]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .requiredCohorts:
-                if idx != 0 { return false }
-            case .cohortOperator:
-                if idx != 1 { return false }
-            case .skipToIdentifier:
-                if idx != 2 { return false }
-            }
-        }
-        return keys.count == 3
+        return CodingKeys.allCases
     }
     
     static func _examples() -> [RSDCohortNavigationRuleObject] {

--- a/Research/Research/RSDCollectionResultObject.swift
+++ b/Research/Research/RSDCollectionResultObject.swift
@@ -67,7 +67,7 @@ public struct RSDCollectionResultObject : RSDCollectionResult, RSDNavigationResu
         self.inputResults = []
     }
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, type, startDate, endDate, inputResults, skipToIdentifier
     }
     
@@ -120,33 +120,7 @@ public struct RSDCollectionResultObject : RSDCollectionResult, RSDNavigationResu
 extension RSDCollectionResultObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .type, .startDate, .endDate, .inputResults, .skipToIdentifier]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .type:
-                if idx != 1 { return false }
-            case .startDate:
-                if idx != 2 { return false }
-            case .endDate:
-                if idx != 3 { return false }
-            case .inputResults:
-                if idx != 4 { return false }
-            case .skipToIdentifier:
-                if idx != 5 { return false }
-            }
-        }
-        return keys.count == 6
+        return CodingKeys.allCases
     }
     
     static func exampleResult() -> RSDCollectionResultObject {

--- a/Research/Research/RSDColorThemeElementObject.swift
+++ b/Research/Research/RSDColorThemeElementObject.swift
@@ -43,7 +43,7 @@ public struct RSDColorThemeElementObject : RSDColorThemeElement, RSDDecodableBun
     let _backgroundColorName: String?
     let _usesLightStyle: Bool?
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case _backgroundColorName = "backgroundColor"
         case _usesLightStyle = "usesLightStyle"
         case bundleIdentifier
@@ -132,29 +132,7 @@ public struct RSDColorThemeElementObject : RSDColorThemeElement, RSDDecodableBun
 extension RSDColorThemeElementObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [._backgroundColorName, ._usesLightStyle, .bundleIdentifier, .colorStyle]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case ._backgroundColorName:
-                if idx != 0 { return false }
-            case ._usesLightStyle:
-                if idx != 1 { return false }
-            case .bundleIdentifier:
-                if idx != 2 { return false }
-            case .colorStyle:
-                if idx != 3 { return false }
-            }
-        }
-        return keys.count == 4
+        return CodingKeys.allCases
     }
     
     static func colorThemeExamples() -> [RSDColorThemeElementObject] {

--- a/Research/Research/RSDComparableSurveyRuleObject.swift
+++ b/Research/Research/RSDComparableSurveyRuleObject.swift
@@ -72,7 +72,7 @@ public struct RSDComparableSurveyRuleObject<T : Codable> : RSDComparableSurveyRu
         self.cohort = cohort
     }
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case skipToIdentifier, matchingValue = "matchingAnswer", ruleOperator, cohort
     }
     
@@ -105,29 +105,7 @@ public struct RSDComparableSurveyRuleObject<T : Codable> : RSDComparableSurveyRu
 extension RSDComparableSurveyRuleObject : RSDDocumentableDecodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.skipToIdentifier, .matchingValue, .ruleOperator, .cohort]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .skipToIdentifier:
-                if idx != 0 { return false }
-            case .matchingValue:
-                if idx != 1 { return false }
-            case .ruleOperator:
-                if idx != 2 { return false }
-            case .cohort:
-                if idx != 3 { return false }
-            }
-        }
-        return keys.count == 4
+        return CodingKeys.allCases
     }
     
     static func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDConditionalStepNavigatorObject.swift
+++ b/Research/Research/RSDConditionalStepNavigatorObject.swift
@@ -36,7 +36,7 @@ import Foundation
 /// `RSDConditionalStepNavigatorObject` is a concrete implementation of the `RSDConditionalStepNavigator` protocol.
 public struct RSDConditionalStepNavigatorObject : RSDConditionalStepNavigator, RSDCopyStepNavigator, Decodable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case steps, conditionalRule, progressMarkers, insertAfterIdentifier
     }
     
@@ -148,29 +148,7 @@ public struct RSDConditionalStepNavigatorObject : RSDConditionalStepNavigator, R
 extension RSDConditionalStepNavigatorObject : RSDDocumentableDecodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.steps, .conditionalRule, .progressMarkers, .insertAfterIdentifier]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .steps:
-                if idx != 0 { return false }
-            case .conditionalRule:
-                if idx != 1 { return false }
-            case .progressMarkers:
-                if idx != 2 { return false }
-            case .insertAfterIdentifier:
-                if idx != 3 { return false }
-            }
-        }
-        return keys.count == 4
+        return CodingKeys.allCases
     }
     
     static func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDDateRangeObject.swift
+++ b/Research/Research/RSDDateRangeObject.swift
@@ -94,7 +94,7 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
         self.init(minimumDate: nil, maximumDate: nil, allowFuture: nil, allowPast: nil, minuteInterval: minuteInterval, dateCoder: dateCoder, defaultDate: defaultDate)
     }
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case minDate = "minimumDate", maxDate = "maximumDate", allowFuture, allowPast, minuteInterval, codingFormat, defaultDate
     }
     
@@ -194,37 +194,8 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
 extension RSDDateRangeObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
+        return CodingKeys.allCases
     }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.minDate, .maxDate, .allowFuture, .allowPast, .minuteInterval, .codingFormat, .defaultDate]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .minDate:
-                if idx != 0 { return false }
-            case .maxDate:
-                if idx != 1 { return false }
-            case .allowFuture:
-                if idx != 2 { return false }
-            case .allowPast:
-                if idx != 3 { return false }
-            case .minuteInterval:
-                if idx != 4 { return false }
-            case .codingFormat:
-                if idx != 5 { return false }
-            case .defaultDate:
-                if idx != 6 { return false }
-            }
-        }
-        return keys.count == 7
-    }
-    
     static func dateRangeExamples() -> [RSDDateRangeObject] {
         let minDate = rsd_ISO8601TimestampFormatter.date(from: "2017-10-16T00:00:00.000-07:00")!
         let maxDate = rsd_ISO8601TimestampFormatter.date(from: "2017-10-17T00:00:00.000-07:00")!

--- a/Research/Research/RSDDetailInputFieldObject.swift
+++ b/Research/Research/RSDDetailInputFieldObject.swift
@@ -35,7 +35,7 @@ import Foundation
 
 open class RSDDetailInputFieldObject : RSDFormUIStepObject, RSDDetailInputField {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case transitionStyle
         case inputPrompt = "prompt"
         case inputPromptDetail = "promptDetail"
@@ -135,35 +135,9 @@ open class RSDDetailInputFieldObject : RSDFormUIStepObject, RSDDetailInputField 
     
     override class func codingKeys() -> [CodingKey] {
         var keys = super.codingKeys()
-        let thisKeys: [CodingKey] = allCodingKeys()
+        let thisKeys: [CodingKey] = CodingKeys.allCases
         keys.append(contentsOf: thisKeys)
         return keys
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.transitionStyle, .inputPrompt, .inputPromptDetail, .placeholder, .inputUIHint]
-        return codingKeys
-    }
-    
-    override class func validateAllKeysIncluded() -> Bool {
-        guard super.validateAllKeysIncluded() else { return false }
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .transitionStyle:
-                if idx != 0 { return false }
-            case .inputPrompt:
-                if idx != 1 { return false }
-            case .inputPromptDetail:
-                if idx != 2 { return false }
-            case .placeholder:
-                if idx != 3 { return false }
-            case .inputUIHint:
-                if idx != 4 { return false }
-                break;
-            }
-        }
-        return keys.count == 5
     }
     
     override class func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDDeviceType.swift
+++ b/Research/Research/RSDDeviceType.swift
@@ -38,7 +38,7 @@ import Foundation
 ///
 /// - note: This is not currently used and may be deprecated.
 ///
-public struct RSDDeviceType : RSDFactoryTypeRepresentable, Codable {
+public struct RSDDeviceType : RSDFactoryTypeRepresentable, Codable, Hashable {
     
     public let rawValue: String
     
@@ -60,39 +60,19 @@ public struct RSDDeviceType : RSDFactoryTypeRepresentable, Codable {
     
     /// A watch is a device that is worn on a person's wrist. (Apple Watch)
     public static let watch: RSDDeviceType = "watch"
-}
-
-extension RSDDeviceType : RSDStringEnumSet {
-    /// List of all the standard types.
-    public static var all: Set<RSDDeviceType> {
+    
+    public static func allStandardKeys() -> [RSDDeviceType] {
         return [.computer, .phone, .tablet, .tv, .watch]
     }
 }
 
 extension RSDDeviceType : RSDDocumentableStringEnum {
-}
-
-extension RSDDeviceType : Equatable {
-    public static func ==(lhs: RSDDeviceType, rhs: RSDDeviceType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-    public static func ==(lhs: String, rhs: RSDDeviceType) -> Bool {
-        return lhs == rhs.rawValue
-    }
-    public static func ==(lhs: RSDDeviceType, rhs: String) -> Bool {
-        return lhs.rawValue == rhs
+    static func allCodingKeys() -> [String] {
+        return allStandardKeys().map { $0.rawValue }
     }
 }
 
-extension RSDDeviceType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
-extension RSDDeviceType : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
+extension RSDDeviceType : ExpressibleByStringLiteral {    
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDDistanceRecorder.swift
+++ b/Research/Research/RSDDistanceRecorder.swift
@@ -503,7 +503,7 @@ public struct RSDDistanceRecord: RSDSampleRecord, RSDDelimiterSeparatedEncodable
     // Returns the speed of the location in m/s; `nil` if speed is invalid.
     public let speed: Double?
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case uptime, timestamp, stepPath, timestampDate, horizontalAccuracy, relativeDistance, latitude, longitude, verticalAccuracy, altitude, totalDistance, course, speed
     }
     
@@ -580,47 +580,7 @@ public struct RSDDistanceRecord: RSDSampleRecord, RSDDelimiterSeparatedEncodable
 extension RSDDistanceRecord : RSDDocumentableCodableObject {
     
     public static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.uptime, .timestamp, .stepPath, .timestampDate, .horizontalAccuracy, .relativeDistance, .latitude, .longitude, .verticalAccuracy, .altitude, .totalDistance, .course, .speed]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .uptime:
-                if idx != 0 { return false }
-            case .timestamp:
-                if idx != 1 { return false }
-            case .stepPath:
-                if idx != 2 { return false }
-            case .timestampDate:
-                if idx != 3 { return false }
-            case .horizontalAccuracy:
-                if idx != 4 { return false }
-            case .relativeDistance:
-                if idx != 5 { return false }
-            case .latitude:
-                if idx != 6 { return false }
-            case .longitude:
-                if idx != 7 { return false }
-            case .verticalAccuracy:
-                if idx != 8 { return false }
-            case .altitude:
-                if idx != 9 { return false }
-            case .totalDistance:
-                if idx != 10 { return false }
-            case .course:
-                if idx != 11 { return false }
-            case .speed:
-                if idx != 12 { return false }
-            }
-        }
-        return keys.count == 13
+        return CodingKeys.allCases
     }
     
     static func examples() -> [Encodable] {

--- a/Research/Research/RSDDistanceRecorderConfiguration.swift
+++ b/Research/Research/RSDDistanceRecorderConfiguration.swift
@@ -53,6 +53,10 @@ import Foundation
 @available(iOS 10.0, *)
 public struct RSDDistanceRecorderConfiguration : RSDRecorderConfiguration, Codable {
     
+    private enum CodingKeys : String, CodingKey, CaseIterable {
+        case identifier, type, motionStepIdentifier, startStepIdentifier, stopStepIdentifier, usesCSVEncoding
+    }
+    
     /// A short string that uniquely identifies the asynchronous action within the task. If started
     /// asynchronously, then the identifier maps to a result stored in `RSDTaskResult.asyncResults`.
     public let identifier: String
@@ -74,10 +78,6 @@ public struct RSDDistanceRecorderConfiguration : RSDRecorderConfiguration, Codab
     
     /// Set the flag to `true` to encode the samples as a CSV file.
     public var usesCSVEncoding : Bool?
-    
-    private enum CodingKeys : String, CodingKey {
-        case identifier, type, motionStepIdentifier, startStepIdentifier, stopStepIdentifier, usesCSVEncoding
-    }
     
     /// Default initializer.
     /// - parameters:
@@ -116,33 +116,7 @@ public struct RSDDistanceRecorderConfiguration : RSDRecorderConfiguration, Codab
 extension RSDDistanceRecorderConfiguration : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .type, .motionStepIdentifier, .startStepIdentifier, .stopStepIdentifier, .usesCSVEncoding]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .type:
-                if idx != 1 { return false }
-            case .motionStepIdentifier:
-                if idx != 2 { return false }
-            case .startStepIdentifier:
-                if idx != 3 { return false }
-            case .stopStepIdentifier:
-                if idx != 4 { return false }
-            case .usesCSVEncoding:
-                if idx != 5 { return false }
-            }
-        }
-        return keys.count == 6
+        return CodingKeys.allCases
     }
     
     static func examples() -> [Encodable] {

--- a/Research/Research/RSDDocumentable.swift
+++ b/Research/Research/RSDDocumentable.swift
@@ -34,17 +34,11 @@
 import Foundation
 
 /// `RSDStringEnumSet` is a protocol for defining the set of all string values included in an enum.
-public protocol RSDStringEnumSet : Hashable, RawRepresentable where RawValue == String {
-    
-    /// The set that includes all the enum values.
-    static var all: Set<Self> { get }
+public protocol RSDStringEnumSet : Hashable, RawRepresentable, CaseIterable where RawValue == String {
 }
 
 /// `RSDIntEnumSet` is a protocol for defining the set of all int values included in an enum.
-public protocol RSDIntEnumSet : Hashable, RawRepresentable where RawValue == Int {
-    
-    /// The set that includes all the enum values.
-    static var all: Set<Self> { get }
+public protocol RSDIntEnumSet : Hashable, RawRepresentable, CaseIterable where RawValue == Int {
 }
 
 public struct RSDDocumentCreator {
@@ -191,7 +185,7 @@ protocol RSDDocumentableStringEnum : RSDDocumentable, Codable {
 /// Any enum set can represent its coding keys by mapping the raw value to a string.
 extension RSDStringEnumSet {
     static func allCodingKeys() -> [String] {
-        return self.all.map{ $0.rawValue }
+        return self.allCases.map{ $0.rawValue }
     }
 }
 
@@ -214,7 +208,7 @@ extension RSDIntEnumSet {
     }
     
     static func allCodingKeys() -> [Int] {
-        return self.all.map{ $0.rawValue }
+        return self.allCases.map{ $0.rawValue }
     }
 }
 
@@ -247,9 +241,6 @@ protocol RSDDocumentableObject : RSDDocumentable {
     
     /// A list of `CodingKey` values for all the `Decodable` properties on this object.
     static func codingKeys() -> [CodingKey]
-    
-    /// Method called during testing to validate that all the coding keys are included.
-    static func validateAllKeysIncluded() -> Bool
 }
 
 /// This is an internal protocol (accessible by test but not externally) that can be used to set up

--- a/Research/Research/RSDDurationRangeObject.swift
+++ b/Research/Research/RSDDurationRangeObject.swift
@@ -76,7 +76,7 @@ public struct RSDDurationRangeObject : RSDDurationRange, RSDRangeWithFormatter, 
         self.formatter = UnitDuration.defaultFormatter(for: units, baseUnit: baseUnit)
     }
 
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case minimumValue, maximumValue, stepInterval, unit, durationUnits
     }
     
@@ -327,31 +327,7 @@ extension NSCalendar.Unit {
 extension RSDDurationRangeObject : RSDDocumentableCodableObject {
 
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.minimumValue, .maximumValue, .stepInterval, .unit, .durationUnits]
-        return codingKeys
-    }
-
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .minimumValue:
-                if idx != 0 { return false }
-            case .maximumValue:
-                if idx != 1 { return false }
-            case .stepInterval:
-                if idx != 2 { return false }
-            case .unit:
-                if idx != 3 { return false }
-            case .durationUnits:
-                if idx != 4 { return false }
-            }
-        }
-        return keys.count == 5
+        return CodingKeys.allCases
     }
 
     static func rangeExamples() -> [RSDDurationRangeObject] {

--- a/Research/Research/RSDErrorResultObject.swift
+++ b/Research/Research/RSDErrorResultObject.swift
@@ -57,7 +57,7 @@ public struct RSDErrorResultObject : RSDErrorResult, Codable {
     /// The error code associated with an `NSError`.
     public let errorCode: Int
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, type, startDate, endDate, errorDescription, errorDomain, errorCode
     }
     
@@ -95,35 +95,7 @@ public struct RSDErrorResultObject : RSDErrorResult, Codable {
 extension RSDErrorResultObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .type, .startDate, .endDate, .errorDescription, .errorDomain, .errorCode]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .type:
-                if idx != 1 { return false }
-            case .startDate:
-                if idx != 2 { return false }
-            case .endDate:
-                if idx != 3 { return false }
-            case .errorDescription:
-                if idx != 4 { return false }
-            case .errorDomain:
-                if idx != 5 { return false }
-            case .errorCode:
-                if idx != 6 { return false }
-            }
-        }
-        return keys.count == 7
+        return CodingKeys.allCases
     }
     
     static func exampleResult() -> RSDErrorResultObject {

--- a/Research/Research/RSDFileResultObject.swift
+++ b/Research/Research/RSDFileResultObject.swift
@@ -68,7 +68,7 @@ public struct RSDFileResultObject : RSDFileResult, Codable {
     /// The MIME content type of the result.
     public var contentType: String?
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, type, startDate, endDate, startUptime, relativePath, contentType
     }
     
@@ -86,35 +86,7 @@ public struct RSDFileResultObject : RSDFileResult, Codable {
 extension RSDFileResultObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .type, .startDate, .endDate, .startUptime, .relativePath, .contentType]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .type:
-                if idx != 1 { return false }
-            case .startDate:
-                if idx != 2 { return false }
-            case .endDate:
-                if idx != 3 { return false }
-            case .startUptime:
-                if idx != 4 { return false }
-            case .relativePath:
-                if idx != 5 { return false }
-            case .contentType:
-                if idx != 6 { return false }
-            }
-        }
-        return keys.count == 7
+        return CodingKeys.allCases
     }
     
     static func exampleResult() -> RSDFileResultObject {

--- a/Research/Research/RSDFormDataType.swift
+++ b/Research/Research/RSDFormDataType.swift
@@ -64,7 +64,7 @@ public enum RSDFormDataType {
     
     /// The base type of the form input field. This is used to indicate what the type is of the
     /// value being prompted and will affect the choice of allowed formatters.
-    public enum BaseType: String {
+    public enum BaseType: String, CaseIterable {
 
         /// The Boolean question type asks the participant to enter Yes or No (or the appropriate equivalents).
         case boolean
@@ -98,16 +98,12 @@ public enum RSDFormDataType {
         
         /// A `Codable` object. This is an object that can be represented using a JSON or XML dictionary.
         case codable
-        
-        public static func allTypes() -> [BaseType] {
-            return [.boolean, .date, .decimal, .fraction, .integer, .string, .duration, .year, .codable]
-        }
     }
     
     /// The collection type for the input field. The supported types are for choice-style questions or
     /// multiple component questions where the user selected from one or more fields to build a single
     /// answer result.
-    public enum CollectionType: String {
+    public enum CollectionType: String, CaseIterable {
         
         /// In a multiple choice question, the participant can pick one or more options.
         case multipleChoice
@@ -118,14 +114,10 @@ public enum RSDFormDataType {
         /// In a multiple component question, the participant can pick one choice from each component
         /// or enter a formatted text string such as a phone number or blood pressure.
         case multipleComponent
-        
-        public static func allTypes() -> [CollectionType] {
-            return [.multipleChoice, .singleChoice, .multipleComponent]
-        }
     }
     
     /// A measurement type is a human-data measurement such as height or weight.
-    public enum MeasurementType: String {
+    public enum MeasurementType: String, CaseIterable {
         
         /// A measurement of height.
         case height
@@ -135,15 +127,11 @@ public enum RSDFormDataType {
         
         /// A measurement of blood pressure.
         case bloodPressure
-        
-        public static func allTypes() -> [MeasurementType] {
-            return [.height, .weight, .bloodPressure]
-        }
     }
     
     /// The measurement range is used to determine units that are appropriate to the
     /// size of the person.
-    public enum MeasurementRange: String {
+    public enum MeasurementRange: String, CaseIterable {
         
         /// Measurement units should be ranged for an adult.
         case adult
@@ -153,10 +141,6 @@ public enum RSDFormDataType {
         
         /// Measuremet units should be ranged for an infant.
         case infant
-        
-        public static func allTypes() -> [MeasurementRange] {
-            return [.adult, .child, .infant]
-        }
     }
     
     /// List of the standard UI hints that are valid for this data type.
@@ -272,13 +256,13 @@ public enum RSDFormDataType {
     
     /// List of all the standard types.
     public static func allStandardTypes() -> [RSDFormDataType] {
-        let baseTypes = BaseType.allTypes()
+        let baseTypes = BaseType.allCases
         let allBase: [RSDFormDataType] = baseTypes.map { .base($0) }
-        let allCollection: [RSDFormDataType] = CollectionType.allTypes().map { (collectionType) -> [RSDFormDataType] in
+        let allCollection: [RSDFormDataType] = CollectionType.allCases.map { (collectionType) -> [RSDFormDataType] in
             return baseTypes.map { .collection(collectionType, $0)}
             }.flatMap { $0 }
-        let allMeasurement: [RSDFormDataType] = MeasurementType.allTypes().map { (measurementType) -> [RSDFormDataType] in
-            return MeasurementRange.allTypes().map { .measurement(measurementType, $0) }
+        let allMeasurement: [RSDFormDataType] = MeasurementType.allCases.map { (measurementType) -> [RSDFormDataType] in
+            return MeasurementRange.allCases.map { .measurement(measurementType, $0) }
         }.flatMap { $0 }
         let allDetail: [RSDFormDataType] = baseTypes.map { .detail($0) }
         return [allBase, allCollection, allMeasurement, allDetail].flatMap { $0 }
@@ -287,10 +271,9 @@ public enum RSDFormDataType {
 
 fileprivate let kDetailCodingKey = "detail"
 
-extension RSDFormDataType: RawRepresentable, Codable {
-    public typealias RawValue = String
+extension RSDFormDataType: RawRepresentable, Codable, Hashable {
     
-    public init?(rawValue: RawValue) {
+    public init?(rawValue: String) {
         let split = rawValue.components(separatedBy: ".")
         if split.count == 1, let subtype = BaseType(rawValue: rawValue) {
             self = .base(subtype)
@@ -351,15 +334,8 @@ extension RSDFormDataType: RawRepresentable, Codable {
     }
 }
 
-extension RSDFormDataType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
 extension RSDFormDataType : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
+
     public init(stringLiteral value: String) {
         self.init(rawValue: value)!
     }

--- a/Research/Research/RSDFormUIHint.swift
+++ b/Research/Research/RSDFormUIHint.swift
@@ -38,61 +38,67 @@ import Foundation
 /// for an input field. Not all ui hints are applicable to all data types or devices, and therefore the ui hint
 /// may be ignored by the application displaying the input field to the user.
 ///
-public struct RSDFormUIHint : RawRepresentable, Codable {
-    public typealias RawValue = String
-    
-    public private(set) var rawValue: String
+public struct RSDFormUIHint : RawRepresentable, Codable, Hashable {
+
+    public let rawValue: String
     
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
     
+    enum StandardHints : String, Codable, CaseIterable {
+        case button, checkbox, combobox, disclosureArrow, link, list, multipleLine, picker, popover, radioButton, section, slider, textfield, toggle
+        
+        var hint: RSDFormUIHint {
+            return RSDFormUIHint(rawValue: self.rawValue)
+        }
+    }
+    
     /// Input field of a button-style cell that can be used to display a detail view.
-    public static let button: RSDFormUIHint = "button"
+    public static let button = StandardHints.button.hint
     
     /// List with a checkbox next to each item.
-    public static let checkbox: RSDFormUIHint = "checkbox"
+    public static let checkbox = StandardHints.checkbox.hint
     
     /// Drop-down with a textfield for "other".
-    public static let combobox: RSDFormUIHint = "combobox"
+    public static let combobox = StandardHints.combobox.hint
     
     /// Input field of a disclosure arrow cell that can be used to display a detail view.
-    public static let disclosureArrow: RSDFormUIHint = "disclosureArrow"
+    public static let disclosureArrow = StandardHints.disclosureArrow.hint
     
     /// Input field of a link-style cell that can be used to display a detail view.
-    public static let link: RSDFormUIHint = "link"
+    public static let link = StandardHints.link.hint
     
     /// List of selectable cells.
-    public static let list: RSDFormUIHint = "list"
+    public static let list = StandardHints.list.hint
     
     /// Multiple line text view.
-    public static let multipleLine: RSDFormUIHint = "multipleLine"
+    public static let multipleLine = StandardHints.multipleLine.hint
     
     /// Text field with a picker wheel as the keyboard.
-    public static let picker: RSDFormUIHint = "picker"
+    public static let picker = StandardHints.picker.hint
     
     /// Text entry using a modal popover box.
-    public static let popover: RSDFormUIHint = "popover"
+    public static let popover = StandardHints.popover.hint
     
     /// Radio button.
-    public static let radioButton: RSDFormUIHint = "radioButton"
+    public static let radioButton = StandardHints.radioButton.hint
     
     /// Input field for a "detail" that is displayed inline as a section.
-    public static let section: RSDFormUIHint = "section"
+    public static let section = StandardHints.section.hint
     
     /// Slider.
-    public static let slider: RSDFormUIHint = "slider"
+    public static let slider = StandardHints.slider.hint
     
     /// Text field.
-    public static let textfield: RSDFormUIHint = "textfield"
+    public static let textfield = StandardHints.textfield.hint
     
     /// Toggle (segmented) button.
-    public static let toggle: RSDFormUIHint = "toggle"
+    public static let toggle = StandardHints.toggle.hint
     
     /// A list of all the `RSDFormUIHint` values that are standard hints.
     public static var allStandardHints: Set<RSDFormUIHint> {
-        return [.button, .checkbox, .combobox, .disclosureArrow, .link, .list, .multipleLine, .picker,
-                .popover, .radioButton, .section, .slider, .textfield, .toggle]
+        return Set(StandardHints.allCases.map { $0.hint })
     }
 }
 
@@ -108,15 +114,7 @@ extension RSDFormUIHint : Equatable {
     }
 }
 
-extension RSDFormUIHint : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
 extension RSDFormUIHint : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDFormUIStepObject.swift
+++ b/Research/Research/RSDFormUIStepObject.swift
@@ -45,7 +45,7 @@ extension CodingUserInfoKey {
 /// a navigable survey.
 open class RSDFormUIStepObject : RSDUIStepObject, RSDFormUIStep, RSDSurveyNavigationStep, RSDCohortAssignmentStep {
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case inputFields, identifier
     }
 
@@ -229,28 +229,9 @@ open class RSDFormUIStepObject : RSDUIStepObject, RSDFormUIStep, RSDSurveyNaviga
     
     override class func codingKeys() -> [CodingKey] {
         var keys = super.codingKeys()
-        let thisKeys: [CodingKey] = allCodingKeys()
+        let thisKeys: [CodingKey] = CodingKeys.allCases
         keys.append(contentsOf: thisKeys)
         return keys
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.inputFields]
-        return codingKeys
-    }
-    
-    override class func validateAllKeysIncluded() -> Bool {
-        guard super.validateAllKeysIncluded() else { return false }
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .inputFields:
-                if idx != 0 { return false }
-            case .identifier:
-                break;
-            }
-        }
-        return keys.count == 1
     }
     
     override class func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDFraction.swift
+++ b/Research/Research/RSDFraction.swift
@@ -89,11 +89,11 @@ extension RSDFraction : ExpressibleByFloatLiteral {
 }
 
 extension RSDFraction : Hashable {
-    
+
     public var hashValue: Int {
         return self.doubleValue.hashValue
     }
-    
+
     public static func ==(lhs: RSDFraction, rhs: RSDFraction) -> Bool {
         return lhs.numerator == rhs.numerator && lhs.denominator == rhs.denominator
     }

--- a/Research/Research/RSDGenericStepObject.swift
+++ b/Research/Research/RSDGenericStepObject.swift
@@ -41,7 +41,7 @@ import Foundation
 ///
 public struct RSDGenericStepObject : RSDGenericStep, Decodable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, stepType = "type"
     }
 

--- a/Research/Research/RSDIdentifier.swift
+++ b/Research/Research/RSDIdentifier.swift
@@ -33,12 +33,12 @@
 
 import Foundation
 
+
+
 /// `RSDIdentifier` is intended to allow a developer to define constants for the identifiers
 /// that are used to define the tasks, steps, input fields, and async actions associated with
 /// a given task or task group.
-///
-/// - note: The base implementation includes "exit"
-public struct RSDIdentifier : RawRepresentable, Codable {
+public struct RSDIdentifier : RawRepresentable, Codable, Hashable {
     public typealias RawValue = String
     
     public private(set) var rawValue: String
@@ -47,12 +47,30 @@ public struct RSDIdentifier : RawRepresentable, Codable {
         self.rawValue = rawValue
     }
     
-    public static let exit: RSDIdentifier = "exit"
-    public static let nextSection: RSDIdentifier = "nextSection"
-    public static let nextStep: RSDIdentifier = "nextStep"
+    enum RestrictedIdentifiers : String, Codable, CaseIterable {
+        case exit, nextSection, nextStep
+    }
+    
+    public static let exit = RestrictedIdentifiers.exit.identifierValue
+    public static let nextSection = RestrictedIdentifiers.nextSection.identifierValue
+    public static let nextStep = RestrictedIdentifiers.nextStep.identifierValue
     
     public static func allGlobalIdentifiers() -> [RSDIdentifier] {
-        return [.exit, .nextSection, .nextStep]
+        return RestrictedIdentifiers.allCases.map { $0.identifierValue }
+    }
+}
+
+extension RawRepresentable where Self.RawValue == String {
+    
+    public var identifierValue: RSDIdentifier {
+        return RSDIdentifier(rawValue: self.rawValue)
+    }
+}
+
+extension RSDIdentifier : ExpressibleByStringLiteral {
+    
+    public init(stringLiteral value: String) {
+        self.init(rawValue: value)
     }
 }
 
@@ -63,22 +81,14 @@ extension RSDIdentifier : Equatable {
     public static func ==(lhs: String, rhs: RSDIdentifier) -> Bool {
         return lhs == rhs.rawValue
     }
+    public static func ==(lhs: String?, rhs: RSDIdentifier) -> Bool {
+        return lhs == rhs.rawValue
+    }
     public static func ==(lhs: RSDIdentifier, rhs: String) -> Bool {
         return lhs.rawValue == rhs
     }
-}
-
-extension RSDIdentifier : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
-extension RSDIdentifier : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
-    public init(stringLiteral value: String) {
-        self.init(rawValue: value)
+    public static func ==(lhs: RSDIdentifier, rhs: String?) -> Bool {
+        return lhs.rawValue == rhs
     }
 }
 

--- a/Research/Research/RSDImagePickerStepObject.swift
+++ b/Research/Research/RSDImagePickerStepObject.swift
@@ -40,7 +40,7 @@ import UIKit
 /// A concrete implementation for a `RSDImagePickerStep`.
 public struct RSDImagePickerStepObject: RSDImagePickerStep, Codable {
 
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, stepType = "type", sourceType, mediaTypes
     }
     

--- a/Research/Research/RSDImagePlacementType.swift
+++ b/Research/Research/RSDImagePlacementType.swift
@@ -34,56 +34,43 @@
 import Foundation
 
 /// A hint as to where the UI should place an image.
-public struct RSDImagePlacementType : RawRepresentable, Codable {
-    public typealias RawValue = String
+public struct RSDImagePlacementType : RawRepresentable, Codable, Hashable {
     
-    public private(set) var rawValue: String
+    public let rawValue: String
     
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
     
+    enum StandardTypes : String, Codable, CaseIterable {
+        case iconBefore, iconAfter, fullsizeBackground, topBackground, topMarginBackground
+        
+        var imagePlacementType: RSDImagePlacementType {
+            return RSDImagePlacementType(rawValue: self.rawValue)
+        }
+    }
+    
     /// Smaller presentation of an icon image before the content.
-    public static let iconBefore: RSDImagePlacementType = "iconBefore"
+    public static let iconBefore = StandardTypes.iconBefore.imagePlacementType
     
     /// Smaller presentation of an icon image after the content.
-    public static let iconAfter: RSDImagePlacementType = "iconAfter"
+    public static let iconAfter = StandardTypes.iconAfter.imagePlacementType
     
     /// Fullsize in the background.
-    public static let fullsizeBackground: RSDImagePlacementType = "fullsizeBackground"
+    public static let fullsizeBackground = StandardTypes.fullsizeBackground.imagePlacementType
     
     /// Top half of the background contrained to the top rather than to the safe area.
-    public static let topBackground: RSDImagePlacementType = "topBackground"
+    public static let topBackground = StandardTypes.topBackground.imagePlacementType
     
     /// Top half of the background constraind to the safe area.
-    public static let topMarginBackground: RSDImagePlacementType = "topMarginBackground"
+    public static let topMarginBackground = StandardTypes.topMarginBackground.imagePlacementType
     
     public static func allStandardTypes() -> [RSDImagePlacementType] {
-        return [.iconBefore, .iconAfter, .fullsizeBackground, .topBackground, .topMarginBackground]
-    }
-}
-
-extension RSDImagePlacementType : Equatable {
-    public static func ==(lhs: RSDImagePlacementType, rhs: RSDImagePlacementType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-    public static func ==(lhs: String, rhs: RSDImagePlacementType) -> Bool {
-        return lhs == rhs.rawValue
-    }
-    public static func ==(lhs: RSDImagePlacementType, rhs: String) -> Bool {
-        return lhs.rawValue == rhs
-    }
-}
-
-extension RSDImagePlacementType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
+        return StandardTypes.allCases.map { $0.imagePlacementType }
     }
 }
 
 extension RSDImagePlacementType : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDImageThemeElementType.swift
+++ b/Research/Research/RSDImageThemeElementType.swift
@@ -35,7 +35,7 @@ import Foundation
 
 /// The type of the ui action. This is used to decode a `RSDUIAction` using a `RSDFactory`. It can also be used
 /// to customize the UI.
-public struct RSDImageThemeElementType : RSDFactoryTypeRepresentable, Codable, Equatable {
+public struct RSDImageThemeElementType : RSDFactoryTypeRepresentable, Codable, Equatable, Hashable {
     public let rawValue: String
     
     public init(rawValue: String) {
@@ -53,15 +53,7 @@ public struct RSDImageThemeElementType : RSDFactoryTypeRepresentable, Codable, E
     }
 }
 
-extension RSDImageThemeElementType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
 extension RSDImageThemeElementType : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDImageThemeObject.swift
+++ b/Research/Research/RSDImageThemeObject.swift
@@ -58,7 +58,7 @@ extension RSDImageWrapper : RSDFetchableImageThemeElement {
 /// `RSDFetchableImageThemeElementObject` is a `Codable` concrete implementation of `RSDFetchableImageThemeElement`.
 public struct RSDFetchableImageThemeElementObject : RSDFetchableImageThemeElement, RSDDecodableBundleInfo, Codable {
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case imageName, bundleIdentifier, placementType, _size = "size"
     }
 
@@ -122,7 +122,7 @@ public struct RSDFetchableImageThemeElementObject : RSDFetchableImageThemeElemen
 /// `RSDAnimatedImageThemeElementObject` is a `Codable` concrete implementation of `RSDAnimatedImageThemeElement`.
 public struct RSDAnimatedImageThemeElementObject : RSDAnimatedImageThemeElement, RSDDecodableBundleInfo, Codable {
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case imageNames, animationDuration, bundleIdentifier, placementType, _size = "size"
     }
     
@@ -239,29 +239,7 @@ struct RSDSizeWrapper : Codable {
 extension RSDFetchableImageThemeElementObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.imageName, .bundleIdentifier, .placementType, ._size]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .imageName:
-                if idx != 0 { return false }
-            case .bundleIdentifier:
-                if idx != 1 { return false }
-            case .placementType:
-                if idx != 2 { return false }
-            case ._size:
-                if idx != 3 { return false }
-            }
-        }
-        return keys.count == 4
+        return CodingKeys.allCases
     }
     
     static func imageThemeExamples() -> [RSDFetchableImageThemeElementObject] {
@@ -278,31 +256,7 @@ extension RSDFetchableImageThemeElementObject : RSDDocumentableCodableObject {
 extension RSDAnimatedImageThemeElementObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.imageNames, .animationDuration, .bundleIdentifier, .placementType, ._size]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .imageNames:
-                if idx != 0 { return false }
-            case .animationDuration:
-                if idx != 1 { return false }
-            case .bundleIdentifier:
-                if idx != 2 { return false }
-            case .placementType:
-                if idx != 3 { return false }
-            case ._size:
-                if idx != 4 { return false }
-            }
-        }
-        return keys.count == 5
+        return CodingKeys.allCases
     }
     
     static func imageThemeExamples() -> [RSDAnimatedImageThemeElementObject] {

--- a/Research/Research/RSDInputFieldObject.swift
+++ b/Research/Research/RSDInputFieldObject.swift
@@ -38,7 +38,7 @@ import Foundation
 ///
 open class RSDInputFieldObject : RSDSurveyInputField, RSDMutableInputField, RSDCopyInputField, Codable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier
         case inputPrompt = "prompt"
         case inputPromptDetail = "promptDetail"
@@ -391,46 +391,12 @@ open class RSDInputFieldObject : RSDSurveyInputField, RSDMutableInputField, RSDC
     // Overrides must be defined in the base implementation
     
     class func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .inputPrompt, .placeholder, .dataType, .inputUIHint, .isOptional, .textFieldOptions, .range, .surveyRules, .inputPromptDetail]
-        return codingKeys
-    }
-    
-    class func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .inputPrompt:
-                if idx != 1 { return false }
-            case .placeholder:
-                if idx != 2 { return false }
-            case .dataType:
-                if idx != 3 { return false }
-            case .inputUIHint:
-                if idx != 4 { return false }
-            case .isOptional:
-                if idx != 5 { return false }
-            case .textFieldOptions:
-                if idx != 6 { return false }
-            case .range:
-                if idx != 7 { return false }
-            case .surveyRules:
-                if idx != 8 { return false }
-            case .inputPromptDetail:
-                if idx != 9 { return false }
-            }
-        }
-        return keys.count == 10
+        return CodingKeys.allCases
     }
     
     class func examples() -> [[String : RSDJSONValue]] {
         
-        let baseTypes = RSDFormDataType.BaseType.allTypes()
+        let baseTypes = RSDFormDataType.BaseType.allCases
         let examples = baseTypes.compactMap { (baseType) -> [String : RSDJSONValue]? in
             switch baseType {
             case .boolean:

--- a/Research/Research/RSDMotionRecorder.swift
+++ b/Research/Research/RSDMotionRecorder.swift
@@ -342,7 +342,7 @@ public struct RSDMotionRecord : RSDSampleRecord, RSDDelimiterSeparatedEncodable 
     /// Used by the attitude quaternion.
     public let w: Double?
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case uptime, timestamp, stepPath, timestampDate, sensorType, eventAccuracy, referenceCoordinate, heading, x, y, z, w
     }
     
@@ -545,47 +545,9 @@ extension CMMagnetometerData : RSDVectorData {
 extension RSDMotionRecord : RSDDocumentableCodableObject {
     
     public static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
+        return CodingKeys.allCases
     }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.uptime, .timestamp, .stepPath, .timestampDate, .sensorType, .eventAccuracy, .referenceCoordinate, .heading, .x, .y, .z, .w]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .uptime:
-                if idx != 0 { return false }
-            case .timestamp:
-                if idx != 1 { return false }
-            case .stepPath:
-                if idx != 2 { return false }
-            case .timestampDate:
-                if idx != 3 { return false }
-            case .sensorType:
-                if idx != 4 { return false }
-            case .eventAccuracy:
-                if idx != 5 { return false }
-            case .referenceCoordinate:
-                if idx != 6 { return false }
-            case .heading:
-                if idx != 7 { return false }
-            case .x:
-                if idx != 8 { return false }
-            case .y:
-                if idx != 9 { return false }
-            case .z:
-                if idx != 10 { return false }
-            case .w:
-                if idx != 11 { return false }
-            }
-        }
-        return keys.count == 12
-    }
-    
+
     static func examples() -> [Encodable] {
         
         let uptime = ProcessInfo.processInfo.systemUptime

--- a/Research/Research/RSDMotionRecorderConfiguration.swift
+++ b/Research/Research/RSDMotionRecorderConfiguration.swift
@@ -210,7 +210,7 @@ public struct RSDMotionRecorderConfiguration : RSDRestartableRecorderConfigurati
     /// Set the flag to `true` to encode the samples as a CSV file.
     public var usesCSVEncoding : Bool?
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, type, recorderTypes, startStepIdentifier, stopStepIdentifier, frequency, _requiresBackgroundAudio = "requiresBackgroundAudio", usesCSVEncoding, _shouldDeletePrevious = "shouldDeletePrevious"
     }
     
@@ -243,39 +243,7 @@ extension RSDMotionRecorderType : RSDDocumentableStringEnum {
 extension RSDMotionRecorderConfiguration : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .recorderTypes, .startStepIdentifier, .stopStepIdentifier, .frequency, ._requiresBackgroundAudio, .type, .usesCSVEncoding, ._shouldDeletePrevious]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .recorderTypes:
-                if idx != 1 { return false }
-            case .startStepIdentifier:
-                if idx != 2 { return false }
-            case .stopStepIdentifier:
-                if idx != 3 { return false }
-            case .frequency:
-                if idx != 4 { return false }
-            case ._requiresBackgroundAudio:
-                if idx != 5 { return false }
-            case .type:
-                if idx != 6 { return false }
-            case .usesCSVEncoding:
-                if idx != 7 { return false }
-            case ._shouldDeletePrevious:
-                if idx != 8 { return false }
-            }
-        }
-        return keys.count == 9
+        return CodingKeys.allCases
     }
     
     static func examples() -> [Encodable] {

--- a/Research/Research/RSDMultipleComponentInputFieldObject.swift
+++ b/Research/Research/RSDMultipleComponentInputFieldObject.swift
@@ -37,7 +37,7 @@ import Foundation
 /// required to create a multiple component input field.
 open class RSDMultipleComponentInputFieldObject : RSDInputFieldObject, RSDMultipleComponentOptions {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case choices, separator, defaultAnswer
     }
     
@@ -178,30 +178,9 @@ open class RSDMultipleComponentInputFieldObject : RSDInputFieldObject, RSDMultip
     
     override class func codingKeys() -> [CodingKey] {
         var keys = super.codingKeys()
-        let thisKeys: [CodingKey] = allCodingKeys()
+        let thisKeys: [CodingKey] = CodingKeys.allCases
         keys.append(contentsOf: thisKeys)
         return keys
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.choices, .separator, .defaultAnswer]
-        return codingKeys
-    }
-    
-    override class func validateAllKeysIncluded() -> Bool {
-        guard super.validateAllKeysIncluded() else { return false }
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .choices:
-                if idx != 0 { return false }
-            case .separator:
-                if idx != 1 { return false }
-            case .defaultAnswer:
-                if idx != 2 { return false }
-            }
-        }
-        return keys.count == 3
     }
     
     override class func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDNumberRangeObject.swift
+++ b/Research/Research/RSDNumberRangeObject.swift
@@ -109,7 +109,7 @@ public struct RSDNumberRangeObject : RSDNumberRange, RSDRangeWithFormatter, Coda
         self.formatter = formatter
     }
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case minimumValue, maximumValue, stepInterval, unit, formatter
     }
     
@@ -174,31 +174,7 @@ public struct RSDNumberRangeObject : RSDNumberRange, RSDRangeWithFormatter, Coda
 extension RSDNumberRangeObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.minimumValue, .maximumValue, .stepInterval, .unit, .formatter]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .minimumValue:
-                if idx != 0 { return false }
-            case .maximumValue:
-                if idx != 1 { return false }
-            case .stepInterval:
-                if idx != 2 { return false }
-            case .unit:
-                if idx != 3 { return false }
-            case .formatter:
-                if idx != 4 { return false }
-            }
-        }
-        return keys.count == 5
+        return CodingKeys.allCases
     }
     
     static func numberRangeExamples() -> [RSDNumberRangeObject] {

--- a/Research/Research/RSDOverviewStepObject.swift
+++ b/Research/Research/RSDOverviewStepObject.swift
@@ -38,7 +38,7 @@ import Foundation
 /// collect the data needed for this task.
 open class RSDOverviewStepObject : RSDUIStepObject, RSDStandardPermissionsStep {
 
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case permissions
     }
     
@@ -79,26 +79,9 @@ open class RSDOverviewStepObject : RSDUIStepObject, RSDStandardPermissionsStep {
     
     override class func codingKeys() -> [CodingKey] {
         var keys = super.codingKeys()
-        let thisKeys: [CodingKey] = allCodingKeys()
+        let thisKeys: [CodingKey] = CodingKeys.allCases
         keys.append(contentsOf: thisKeys)
         return keys
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.permissions]
-        return codingKeys
-    }
-    
-    override class func validateAllKeysIncluded() -> Bool {
-        guard super.validateAllKeysIncluded() else { return false }
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .permissions:
-                if idx != 0 { return false }
-            }
-        }
-        return keys.count == 1
     }
     
     override class func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDPermissionType.swift
+++ b/Research/Research/RSDPermissionType.swift
@@ -72,7 +72,7 @@ public enum RSDAuthorizationStatus : Int {
 ///         this framework is to include a model that is platform-agnostic and can be used
 ///         independently of the device. (syoung 11/1/7/2017)
 ///
-public enum RSDStandardPermissionType: String, RSDPermissionType, Codable {
+public enum RSDStandardPermissionType: String, RSDPermissionType, Codable, CaseIterable {
     
     /// “Privacy - Camera Usage Description”
     /// Specifies the reason for your app to access the device’s camera.
@@ -113,16 +113,11 @@ public enum RSDStandardPermissionType: String, RSDPermissionType, Codable {
     public var asyncActionType: RSDAsyncActionType {
         return RSDAsyncActionType(rawValue: self.rawValue)
     }
-    
-    /// List of all the standard types.
-    public static func allStandardTypes() -> [RSDStandardPermissionType] {
-        return [.camera, .locationWhenInUse, .location, .microphone, .motion, .photoLibrary]
-    }
 }
 
 extension RSDStandardPermissionType : RSDDocumentableStringEnum {
     static func allCodingKeys() -> [String] {
-        return allStandardTypes().map{ $0.rawValue }
+        return allCases.map{ $0.rawValue }
     }
 }
 
@@ -130,7 +125,7 @@ extension RSDStandardPermissionType : RSDDocumentableStringEnum {
 /// the associated activity, task, or step.
 public struct RSDStandardPermission : Codable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case permissionType
         case title
         case reason

--- a/Research/Research/RSDPopoverInputFieldObject.swift
+++ b/Research/Research/RSDPopoverInputFieldObject.swift
@@ -123,7 +123,7 @@ open class RSDPopoverInputFieldObject : RSDFormUIStepObject, RSDPopoverInputFiel
         mutableField.inputPromptDetail = nil
     }
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case prompt, promptDetail, placeholder
     }
     

--- a/Research/Research/RSDResourceTransformerObject.swift
+++ b/Research/Research/RSDResourceTransformerObject.swift
@@ -37,7 +37,7 @@ import Foundation
 /// The transformer can be used to create an object decoded from an embedded resource.
 public final class RSDResourceTransformerObject : Codable {
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case resourceName, bundleIdentifier, classType
     }
     
@@ -90,27 +90,7 @@ extension RSDResourceTransformerObject : RSDTaskResourceTransformer {
 extension RSDResourceTransformerObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.resourceName, .bundleIdentifier, .classType]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .resourceName:
-                if idx != 0 { return false }
-            case .bundleIdentifier:
-                if idx != 1 { return false }
-            case .classType:
-                if idx != 2 { return false }
-            }
-        }
-        return keys.count == 3
+        return CodingKeys.allCases
     }
     
     static func codingMap() -> Array<(CodingKey, Any.Type, String)> {

--- a/Research/Research/RSDResultObject.swift
+++ b/Research/Research/RSDResultObject.swift
@@ -52,7 +52,7 @@ public struct RSDResultObject : RSDNavigationResult, Codable {
     /// navigation handling.
     public var skipToIdentifier: String?
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, type, startDate, endDate, skipToIdentifier
     }
     
@@ -70,31 +70,7 @@ public struct RSDResultObject : RSDNavigationResult, Codable {
 extension RSDResultObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .type, .startDate, .endDate, .skipToIdentifier]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .type:
-                if idx != 1 { return false }
-            case .startDate:
-                if idx != 2 { return false }
-            case .endDate:
-                if idx != 3 { return false }
-            case .skipToIdentifier:
-                if idx != 4 { return false }
-            }
-        }
-        return keys.count == 5
+        return CodingKeys.allCases
     }
     
     static func examples() -> [Encodable] {

--- a/Research/Research/RSDResultType.swift
+++ b/Research/Research/RSDResultType.swift
@@ -34,7 +34,7 @@ import Foundation
 
 /// `RSDResultType` is an extendable string enum used by `RSDFactory` to create the appropriate
 /// result type.
-public struct RSDResultType : RSDFactoryTypeRepresentable, Codable {
+public struct RSDResultType : RSDFactoryTypeRepresentable, Codable, Hashable {
     
     public let rawValue: String
     
@@ -69,27 +69,7 @@ public struct RSDResultType : RSDFactoryTypeRepresentable, Codable {
     }
 }
 
-extension RSDResultType : Equatable {
-    public static func ==(lhs: RSDResultType, rhs: RSDResultType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-    public static func ==(lhs: String, rhs: RSDResultType) -> Bool {
-        return lhs == rhs.rawValue
-    }
-    public static func ==(lhs: RSDResultType, rhs: String) -> Bool {
-        return lhs.rawValue == rhs
-    }
-}
-
-extension RSDResultType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
-extension RSDResultType : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
+extension RSDResultType : ExpressibleByStringLiteral {    
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDSampleRecorder.swift
+++ b/Research/Research/RSDSampleRecorder.swift
@@ -108,7 +108,7 @@ public struct RSDRecordMarker : RSDSampleRecord {
     ///            "timestamp": 0
     ///        }
     ///     ```
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case uptime, stepPath, timestampDate, timestamp
     }
 }
@@ -863,29 +863,7 @@ public class RSDRecordSampleLogger : RSDDataLogger {
 extension RSDRecordMarker : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.uptime, .stepPath, .timestampDate, .timestamp]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .uptime:
-                if idx != 0 { return false }
-            case .stepPath:
-                if idx != 1 { return false }
-            case .timestampDate:
-                if idx != 2 { return false }
-            case .timestamp:
-                if idx != 3 { return false }
-            }
-        }
-        return keys.count == 4
+        return CodingKeys.allCases
     }
     
     static func examples() -> [Encodable] {

--- a/Research/Research/RSDSchemaInfoObject.swift
+++ b/Research/Research/RSDSchemaInfoObject.swift
@@ -34,7 +34,7 @@
 import Foundation
 
 /// `RSDSchemaInfoObject` is a concrete implementation of the `RSDSchemaInfo` protocol.
-public struct RSDSchemaInfoObject : RSDSchemaInfo, Codable {
+public struct RSDSchemaInfoObject : RSDSchemaInfo, Codable, Hashable {
     private let identifier: String
     private let revision: Int
     
@@ -48,7 +48,7 @@ public struct RSDSchemaInfoObject : RSDSchemaInfo, Codable {
         return revision
     }
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case identifier, revision
     }
     
@@ -62,41 +62,10 @@ public struct RSDSchemaInfoObject : RSDSchemaInfo, Codable {
     }
 }
 
-extension RSDSchemaInfoObject : Equatable {
-    public static func ==(lhs: RSDSchemaInfoObject, rhs: RSDSchemaInfoObject) -> Bool {
-        return lhs.schemaIdentifier == rhs.schemaIdentifier &&
-            lhs.schemaVersion == rhs.schemaVersion
-    }
-}
-
-extension RSDSchemaInfoObject : Hashable {
-    public var hashValue : Int {
-        return (schemaIdentifier?.hashValue ?? 0) ^ schemaVersion
-    }
-}
-
 extension RSDSchemaInfoObject : RSDDocumentableDecodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .revision]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .revision:
-                if idx != 1 { return false }
-            }
-        }
-        return keys.count == 2
+        return CodingKeys.allCases
     }
     
     static func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDSectionStepObject.swift
+++ b/Research/Research/RSDSectionStepObject.swift
@@ -37,7 +37,7 @@ import Foundation
 /// step that includes an instruction step, countdown step, and activity step.
 public struct RSDSectionStepObject: RSDSectionStep, RSDConditionalStepNavigator, RSDStepValidator, RSDCopyStep, Decodable {
 
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, stepType = "type", steps, progressMarkers, asyncActions
     }
     
@@ -189,31 +189,7 @@ public struct RSDSectionStepObject: RSDSectionStep, RSDConditionalStepNavigator,
 extension RSDSectionStepObject : RSDDocumentableDecodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .stepType, .steps, .progressMarkers, .asyncActions]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .stepType:
-                if idx != 1 { return false }
-            case .steps:
-                if idx != 2 { return false }
-            case .progressMarkers:
-                if idx != 3 { return false }
-            case .asyncActions:
-                if idx != 4 { return false }
-            }
-        }
-        return keys.count == 5
+        return CodingKeys.allCases
     }
     
     static func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDStandardAsyncActionConfiguration.swift
+++ b/Research/Research/RSDStandardAsyncActionConfiguration.swift
@@ -36,6 +36,10 @@ import Foundation
 /// `RSDStandardAsyncActionConfiguration` is a concrete implementation of `RSDRecorderConfiguration` that can be used to
 /// decode an async configuration for a recorder.
 public struct RSDStandardAsyncActionConfiguration : RSDRecorderConfiguration, Codable {
+    
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case identifier, type, startStepIdentifier, stopStepIdentifier, _permissions = "permissions", _requiresBackgroundAudio = "requiresBackgroundAudio"
+    }
 
     /// A short string that uniquely identifies the asynchronous action within the task. If started asynchronously,
     /// then the identifier maps to a result stored in `RSDTaskResult.asyncResults`.
@@ -51,10 +55,6 @@ public struct RSDStandardAsyncActionConfiguration : RSDRecorderConfiguration, Co
     /// An identifier marking the step at which to stop the action. If `nil`, then the action will be
     /// stopped when the task is stopped.
     public var stopStepIdentifier: String?
-    
-    private enum CodingKeys: String, CodingKey {
-        case identifier, type, startStepIdentifier, stopStepIdentifier, _permissions = "permissions", _requiresBackgroundAudio = "requiresBackgroundAudio"
-    }
     
     /// List of the permissions required for this action.
     public var permissionTypes: [RSDPermissionType] {
@@ -103,37 +103,11 @@ public struct RSDStandardAsyncActionConfiguration : RSDRecorderConfiguration, Co
 extension RSDStandardAsyncActionConfiguration : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .type, .startStepIdentifier, .stopStepIdentifier, ._permissions, ._requiresBackgroundAudio]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .type:
-                if idx != 1 { return false }
-            case .startStepIdentifier:
-                if idx != 2 { return false }
-            case .stopStepIdentifier:
-                if idx != 3 { return false }
-            case ._permissions:
-                if idx != 4 { return false }
-            case ._requiresBackgroundAudio:
-                if idx != 5 { return false }
-            }
-        }
-        return keys.count == 6
+        return CodingKeys.allCases
     }
     
     static func examples() -> [Encodable] {
-        let types = RSDStandardPermissionType.allStandardTypes()
+        let types = RSDStandardPermissionType.allCases
         return types.map { RSDStandardAsyncActionConfiguration(identifier: $0.rawValue, type: $0.asyncActionType, startStepIdentifier: "\($0.rawValue)StartStep", stopStepIdentifier: "\($0.rawValue)StopStep") }
     }
 }

--- a/Research/Research/RSDStepNavigatorType.swift
+++ b/Research/Research/RSDStepNavigatorType.swift
@@ -35,7 +35,7 @@ import Foundation
 
 /// The type of the step. This is used to decode the step using a `RSDFactory`. It can also be used to customize
 /// the UI.
-public struct RSDStepNavigatorType : RSDFactoryTypeRepresentable, Codable {
+public struct RSDStepNavigatorType : RSDFactoryTypeRepresentable, Codable, Hashable {
     
     public let rawValue: String
     
@@ -49,21 +49,6 @@ public struct RSDStepNavigatorType : RSDFactoryTypeRepresentable, Codable {
     /// List of all the standard types.
     public static func allStandardTypes() -> [RSDStepNavigatorType] {
         return [.conditional]
-    }
-}
-
-extension RSDStepNavigatorType : Equatable {
-    public static func ==(lhs: String, rhs: RSDStepNavigatorType) -> Bool {
-        return lhs == rhs.rawValue
-    }
-    public static func ==(lhs: RSDStepNavigatorType, rhs: String) -> Bool {
-        return lhs.rawValue == rhs
-    }
-}
-
-extension RSDStepNavigatorType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
     }
 }
 

--- a/Research/Research/RSDStepTransformerObject.swift
+++ b/Research/Research/RSDStepTransformerObject.swift
@@ -38,7 +38,7 @@ import Foundation
 /// `RSDSectionStep` from the decoded object.
 public struct RSDStepTransformerObject : RSDStepTransformer, Decodable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, resourceTransformer
     }
     
@@ -108,25 +108,7 @@ fileprivate struct _StepDecoder: Decodable {
 extension RSDStepTransformerObject : RSDDocumentableDecodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .resourceTransformer]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .resourceTransformer:
-                if idx != 1 { return false }
-            }
-        }
-        return keys.count == 2
+        return CodingKeys.allCases
     }
     
     static func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDStepType.swift
+++ b/Research/Research/RSDStepType.swift
@@ -35,7 +35,7 @@ import Foundation
 
 /// The type of the step. This is used to decode the step using a `RSDFactory`. It can also be used to customize
 /// the UI.
-public struct RSDStepType : RSDFactoryTypeRepresentable, Codable {
+public struct RSDStepType : RSDFactoryTypeRepresentable, Codable, Hashable {
     
     public let rawValue: String
     
@@ -82,27 +82,7 @@ public struct RSDStepType : RSDFactoryTypeRepresentable, Codable {
     }
 }
 
-extension RSDStepType : Equatable {
-    public static func ==(lhs: RSDStepType, rhs: RSDStepType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-    public static func ==(lhs: String, rhs: RSDStepType) -> Bool {
-        return lhs == rhs.rawValue
-    }
-    public static func ==(lhs: RSDStepType, rhs: String) -> Bool {
-        return lhs.rawValue == rhs
-    }
-}
-
-extension RSDStepType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
 extension RSDStepType : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDSurveyRuleOperator.swift
+++ b/Research/Research/RSDSurveyRuleOperator.swift
@@ -65,11 +65,6 @@ public enum RSDSurveyRuleOperator: String, Codable, RSDStringEnumSet {
     /// `[2,4]` then this will evaluate to `true` and return the `skipIdentifier` because neither `2` nor
     /// `4` are in the set defined by the `matchingAnswer`.
     case otherThan          = "ot"
-    
-    /// List of all the operators.
-    public static var all: Set<RSDSurveyRuleOperator> {
-        return [.skip, .equal, .notEqual, .lessThan, .greaterThan, .lessThanEqual, .greaterThanEqual, .otherThan]
-    }
 }
 
 extension RSDSurveyRuleOperator : RSDDocumentableStringEnum {

--- a/Research/Research/RSDTaskGroupObject.swift
+++ b/Research/Research/RSDTaskGroupObject.swift
@@ -36,7 +36,7 @@ import Foundation
 /// `RSDTaskGroupObject` is a concrete implementation of the `RSDTaskGroup` protocol.
 public struct RSDTaskGroupObject : RSDTaskGroup, RSDEmbeddedIconVendor, Decodable {
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case identifier, title, detail, icon, tasks
     }
 
@@ -123,31 +123,7 @@ public struct RSDTaskGroupObject : RSDTaskGroup, RSDEmbeddedIconVendor, Decodabl
 extension RSDTaskGroupObject : RSDDocumentableDecodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .title, .detail, .icon, .tasks]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .title:
-                if idx != 1 { return false }
-            case .detail:
-                if idx != 2 { return false }
-            case .icon:
-                if idx != 3 { return false }
-            case .tasks:
-                if idx != 4 { return false }
-            }
-        }
-        return keys.count == 5
+        return CodingKeys.allCases
     }
     
     static func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDTaskInfoStepObject.swift
+++ b/Research/Research/RSDTaskInfoStepObject.swift
@@ -35,7 +35,7 @@ import Foundation
 
 public struct RSDTaskInfoObject : RSDTaskInfo, RSDEmbeddedIconVendor, Decodable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, title, subtitle, detail, icon, _estimatedMinutes = "estimatedMinutes", _embeddedResource = "taskTransformer", _schemaInfoObject = "schemaInfo"
     }
     
@@ -161,37 +161,7 @@ extension RSDTaskInfoObject : RSDTaskGroup {
 extension RSDTaskInfoObject : RSDDocumentableDecodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .title, .subtitle, .detail, .icon, ._estimatedMinutes, ._embeddedResource, ._schemaInfoObject]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .title:
-                if idx != 1 { return false }
-            case .subtitle:
-                if idx != 2 { return false }
-            case .detail:
-                if idx != 3 { return false }
-            case .icon:
-                if idx != 4 { return false }
-            case ._estimatedMinutes:
-                if idx != 5 { return false }
-            case ._embeddedResource:
-                if idx != 6 { return false }
-            case ._schemaInfoObject:
-                if idx != 7 { return false }
-            }
-        }
-        return keys.count == 8
+        return CodingKeys.allCases
     }
     
     static func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDTaskObject.swift
+++ b/Research/Research/RSDTaskObject.swift
@@ -37,7 +37,7 @@ import Foundation
 /// validation, and the order of display for the steps.
 public class RSDTaskObject : RSDUIActionHandlerObject, RSDCopyTask, Decodable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, copyright, schemaInfo, asyncActions
     }
 
@@ -207,32 +207,9 @@ public class RSDTaskObject : RSDUIActionHandlerObject, RSDCopyTask, Decodable {
     
     override class func codingKeys() -> [CodingKey] {
         var keys = super.codingKeys()
-        let thisKeys: [CodingKey] = allCodingKeys()
+        let thisKeys: [CodingKey] = CodingKeys.allCases
         keys.append(contentsOf: thisKeys)
         return keys
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .copyright, .schemaInfo, .asyncActions]
-        return codingKeys
-    }
-    
-    override class func validateAllKeysIncluded() -> Bool {
-        guard super.validateAllKeysIncluded() else { return false }
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .copyright:
-                if idx != 1 { return false }
-            case .schemaInfo:
-                if idx != 2 { return false }
-            case .asyncActions:
-                if idx != 3 { return false }
-            }
-        }
-        return keys.count == 4
     }
     
     class func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDTaskResultObject.swift
+++ b/Research/Research/RSDTaskResultObject.swift
@@ -74,7 +74,7 @@ public struct RSDTaskResultObject : RSDTaskResult, Codable {
         self.type = .task
     }
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, type, startDate, endDate, taskRunUUID, schemaInfo, stepHistory, asyncResults
     }
     
@@ -138,37 +138,7 @@ public struct RSDTaskResultObject : RSDTaskResult, Codable {
 extension RSDTaskResultObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .type, .startDate, .endDate, .taskRunUUID, .schemaInfo, .stepHistory, .asyncResults]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .type:
-                if idx != 1 { return false }
-            case .startDate:
-                if idx != 2 { return false }
-            case .endDate:
-                if idx != 3 { return false }
-            case .taskRunUUID:
-                if idx != 4 { return false }
-            case .schemaInfo:
-                if idx != 5 { return false }
-            case .stepHistory:
-                if idx != 6 { return false }
-            case .asyncResults:
-                if idx != 7 { return false }
-            }
-        }
-        return keys.count == 8
+        return CodingKeys.allCases
     }
     
     static func exampleResult() -> RSDTaskResultObject {

--- a/Research/Research/RSDTextFieldOptionsObject.swift
+++ b/Research/Research/RSDTextFieldOptionsObject.swift
@@ -67,7 +67,7 @@ public struct RSDTextFieldOptionsObject : RSDTextFieldOptions, Codable {
     /// Is the text field for password entry?
     public var isSecureTextEntry: Bool
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case textValidator, invalidMessage, maximumLength, isSecureTextEntry, autocapitalizationType, autocorrectionType, spellCheckingType, keyboardType
     }
     
@@ -158,37 +158,7 @@ public struct RSDTextFieldOptionsObject : RSDTextFieldOptions, Codable {
 extension RSDTextFieldOptionsObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.textValidator, .invalidMessage, .maximumLength, .isSecureTextEntry, .autocapitalizationType, .autocorrectionType, .spellCheckingType, .keyboardType]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .textValidator:
-                if idx != 0 { return false }
-            case .invalidMessage:
-                if idx != 1 { return false }
-            case .maximumLength:
-                if idx != 2 { return false }
-            case .isSecureTextEntry:
-                if idx != 3 { return false }
-            case .autocapitalizationType:
-                if idx != 4 { return false }
-            case .autocorrectionType:
-                if idx != 5 { return false }
-            case .spellCheckingType:
-                if idx != 6 { return false }
-            case .keyboardType:
-                if idx != 7 { return false }
-            }
-        }
-        return keys.count == 8
+        return CodingKeys.allCases
     }
     
     static func examples() -> [Encodable] {

--- a/Research/Research/RSDUIActionHandlerObject.swift
+++ b/Research/Research/RSDUIActionHandlerObject.swift
@@ -77,7 +77,7 @@ open class RSDUIActionHandlerObject : RSDUIActionHandler {
     
     // MARK: Codable (must implement in base class in order for the overriding classes to work)
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case actions, shouldHideActions
     }
     
@@ -151,24 +151,6 @@ open class RSDUIActionHandlerObject : RSDUIActionHandler {
     }
     
     class func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.actions, .shouldHideActions]
-        return codingKeys
-    }
-    
-    class func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .actions:
-                if idx != 0 { return false }
-            case .shouldHideActions:
-                if idx != 1 { return false }
-            }
-        }
-        return keys.count == 2
+        return CodingKeys.allCases
     }
 }

--- a/Research/Research/RSDUIActionObject.swift
+++ b/Research/Research/RSDUIActionObject.swift
@@ -64,7 +64,7 @@ extension RSDEmbeddedResourceUIAction {
 /// title and image displayed for a given action of the UI.
 public struct RSDUIActionObject : RSDEmbeddedResourceUIAction, Codable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case buttonTitle, iconName, bundleIdentifier
     }
     
@@ -112,7 +112,7 @@ public struct RSDUIActionObject : RSDEmbeddedResourceUIAction, Codable {
 /// `RSDNavigationUIActionObject` implements an action for navigating to another step in a task.
 public struct RSDNavigationUIActionObject : RSDEmbeddedResourceUIAction, RSDNavigationUIAction, Codable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case skipToIdentifier, buttonTitle, iconName, bundleIdentifier
     }
     
@@ -145,7 +145,7 @@ public struct RSDNavigationUIActionObject : RSDEmbeddedResourceUIAction, RSDNavi
 /// the participant about doing a particular task later.
 public struct RSDReminderUIActionObject : RSDEmbeddedResourceUIAction, RSDReminderUIAction, Codable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case reminderIdentifier, _buttonTitle = "buttonTitle", iconName, bundleIdentifier
     }
     
@@ -181,7 +181,7 @@ public struct RSDReminderUIActionObject : RSDEmbeddedResourceUIAction, RSDRemind
 /// webview. The url can either be fully qualified or optionally point to an embedded resource. 
 public struct RSDWebViewUIActionObject : RSDEmbeddedResourceUIAction, RSDWebViewUIAction, Codable {
 
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case  url, buttonTitle, iconName, bundleIdentifier
     }
     
@@ -238,28 +238,10 @@ public struct RSDWebViewUIActionObject : RSDEmbeddedResourceUIAction, RSDWebView
 extension RSDUIActionObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
+        return CodingKeys.allCases
     }
     
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.buttonTitle, .iconName, .bundleIdentifier]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .buttonTitle:
-                if idx != 0 { return false }
-            case .iconName:
-                if idx != 1 { return false }
-            case .bundleIdentifier:
-                if idx != 2 { return false }
-            }
-        }
-        return keys.count == 3
-    }
+
     
     static func actionExamples() -> [RSDUIActionObject] {
         let titleAction = RSDUIActionObject(buttonTitle: "Go, Dogs! Go")
@@ -275,29 +257,7 @@ extension RSDUIActionObject : RSDDocumentableCodableObject {
 extension RSDNavigationUIActionObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.buttonTitle, .iconName, .bundleIdentifier, .skipToIdentifier]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .buttonTitle:
-                if idx != 0 { return false }
-            case .iconName:
-                if idx != 1 { return false }
-            case .bundleIdentifier:
-                if idx != 2 { return false }
-            case .skipToIdentifier:
-                if idx != 3 { return false }
-            }
-        }
-        return keys.count == 4
+        return CodingKeys.allCases
     }
     
     static func actionExamples() -> [RSDNavigationUIActionObject] {
@@ -313,29 +273,7 @@ extension RSDNavigationUIActionObject : RSDDocumentableCodableObject {
 extension RSDWebViewUIActionObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.buttonTitle, .iconName, .bundleIdentifier, .url]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .buttonTitle:
-                if idx != 0 { return false }
-            case .iconName:
-                if idx != 1 { return false }
-            case .bundleIdentifier:
-                if idx != 2 { return false }
-            case .url:
-                if idx != 3 { return false }
-            }
-        }
-        return keys.count == 4
+        return CodingKeys.allCases
     }
     
     static func actionExamples() -> [RSDWebViewUIActionObject] {

--- a/Research/Research/RSDUIActionObjectType.swift
+++ b/Research/Research/RSDUIActionObjectType.swift
@@ -35,7 +35,7 @@ import Foundation
 
 /// The type of the ui action. This is used to decode a `RSDUIAction` using a `RSDFactory`. It can also be used
 /// to customize the UI.
-public struct RSDUIActionObjectType : RSDFactoryTypeRepresentable, Codable {
+public struct RSDUIActionObjectType : RSDFactoryTypeRepresentable, Codable, Hashable {
     
     public let rawValue: String
     
@@ -60,27 +60,7 @@ public struct RSDUIActionObjectType : RSDFactoryTypeRepresentable, Codable {
     }
 }
 
-extension RSDUIActionObjectType : Equatable {
-    public static func ==(lhs: RSDUIActionObjectType, rhs: RSDUIActionObjectType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-    public static func ==(lhs: String, rhs: RSDUIActionObjectType) -> Bool {
-        return lhs == rhs.rawValue
-    }
-    public static func ==(lhs: RSDUIActionObjectType, rhs: String) -> Bool {
-        return lhs.rawValue == rhs
-    }
-}
-
-extension RSDUIActionObjectType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
-extension RSDUIActionObjectType : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
+extension RSDUIActionObjectType : ExpressibleByStringLiteral {    
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDUIActionType.swift
+++ b/Research/Research/RSDUIActionType.swift
@@ -72,10 +72,9 @@ public enum RSDUIActionType {
     }
 }
 
-extension RSDUIActionType: RawRepresentable, Codable {
-    public typealias RawValue = String
+extension RSDUIActionType: RawRepresentable, Codable, Hashable {
     
-    public init(rawValue: RawValue) {
+    public init(rawValue: String) {
         if let subtype = Navigation(rawValue: rawValue) {
             self = .navigation(subtype)
         }
@@ -95,27 +94,7 @@ extension RSDUIActionType: RawRepresentable, Codable {
     }
 }
 
-extension RSDUIActionType : Equatable {
-    public static func ==(lhs: RSDUIActionType, rhs: RSDUIActionType) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-    public static func ==(lhs: String, rhs: RSDUIActionType) -> Bool {
-        return lhs == rhs.rawValue
-    }
-    public static func ==(lhs: RSDUIActionType, rhs: String) -> Bool {
-        return lhs.rawValue == rhs
-    }
-}
-
-extension RSDUIActionType : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
 extension RSDUIActionType : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDUIStepObject.swift
+++ b/Research/Research/RSDUIStepObject.swift
@@ -40,7 +40,7 @@ import Foundation
 /// - seealso: `RSDActiveUIStepObject`, `RSDFormUIStepObject`, and `RSDThemedUIStep`
 open class RSDUIStepObject : RSDUIActionHandlerObject, RSDThemedUIStep, RSDTableStep, RSDNavigationRule, RSDCohortNavigationStep, Decodable, RSDCopyStep, RSDDecodableReplacement {
 
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case identifier
         case stepType = "type"
         case title
@@ -341,48 +341,9 @@ open class RSDUIStepObject : RSDUIActionHandlerObject, RSDThemedUIStep, RSDTable
     
     override class func codingKeys() -> [CodingKey] {
         var keys = super.codingKeys()
-        let thisKeys: [CodingKey] = allCodingKeys()
+        let thisKeys: [CodingKey] = CodingKeys.allCases
         keys.append(contentsOf: thisKeys)
         return keys
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .stepType, .title, .text, .detail, .footnote, .nextStepIdentifier, .viewTheme, .colorTheme, .imageTheme, .beforeCohortRules, .afterCohortRules]
-        return codingKeys
-    }
-    
-    override class func validateAllKeysIncluded() -> Bool {
-        guard super.validateAllKeysIncluded() else { return false }
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .identifier:
-                if idx != 0 { return false }
-            case .stepType:
-                if idx != 1 { return false }
-            case .title:
-                if idx != 2 { return false }
-            case .text:
-                if idx != 3 { return false }
-            case .detail:
-                if idx != 4 { return false }
-            case .footnote:
-                if idx != 5 { return false }
-            case .nextStepIdentifier:
-                if idx != 6 { return false }
-            case .viewTheme:
-                if idx != 7 { return false }
-            case .colorTheme:
-                if idx != 8 { return false }
-            case .imageTheme:
-                if idx != 9 { return false }
-            case .beforeCohortRules:
-                if idx != 10 { return false }
-            case .afterCohortRules:
-                if idx != 11 { return false }
-            }
-        }
-        return keys.count == 12
     }
     
     class func examples() -> [[String : RSDJSONValue]] {

--- a/Research/Research/RSDUITransitionStyle.swift
+++ b/Research/Research/RSDUITransitionStyle.swift
@@ -34,10 +34,9 @@
 import Foundation
 
 /// The type of transition style to use for displaying a UI component.
-public struct RSDTransitionStyle : RawRepresentable, Codable {
-    public typealias RawValue = String
+public struct RSDTransitionStyle : RawRepresentable, Codable, Hashable {
     
-    public private(set) var rawValue: String
+    public let rawValue: String
     
     public init(rawValue: String) {
         self.rawValue = rawValue
@@ -50,27 +49,7 @@ public struct RSDTransitionStyle : RawRepresentable, Codable {
     }
 }
 
-extension RSDTransitionStyle : Equatable {
-    public static func ==(lhs: RSDTransitionStyle, rhs: RSDTransitionStyle) -> Bool {
-        return lhs.rawValue == rhs.rawValue
-    }
-    public static func ==(lhs: String, rhs: RSDTransitionStyle) -> Bool {
-        return lhs == rhs.rawValue
-    }
-    public static func ==(lhs: RSDTransitionStyle, rhs: String) -> Bool {
-        return lhs.rawValue == rhs
-    }
-}
-
-extension RSDTransitionStyle : Hashable {
-    public var hashValue : Int {
-        return self.rawValue.hashValue
-    }
-}
-
 extension RSDTransitionStyle : ExpressibleByStringLiteral {
-    public typealias StringLiteralType = String
-    
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }

--- a/Research/Research/RSDViewThemeElementObject.swift
+++ b/Research/Research/RSDViewThemeElementObject.swift
@@ -37,7 +37,7 @@ import Foundation
 /// the `RSDStepController`.
 public struct RSDViewThemeElementObject: RSDViewThemeElement, RSDDecodableBundleInfo, Codable {
     
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case viewIdentifier, bundleIdentifier, storyboardIdentifier
     }
     
@@ -71,27 +71,7 @@ public struct RSDViewThemeElementObject: RSDViewThemeElement, RSDDecodableBundle
 extension RSDViewThemeElementObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.viewIdentifier, .bundleIdentifier, .storyboardIdentifier]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .viewIdentifier:
-                if idx != 0 { return false }
-            case .bundleIdentifier:
-                if idx != 1 { return false }
-            case .storyboardIdentifier:
-                if idx != 2 { return false }
-            }
-        }
-        return keys.count == 3
+        return CodingKeys.allCases
     }
     
     static func viewThemeExamples() -> [RSDViewThemeElementObject] {

--- a/Research/Research/RSDWeeklyScheduleObject.swift
+++ b/Research/Research/RSDWeeklyScheduleObject.swift
@@ -47,7 +47,7 @@ import Foundation
 /// ```
 public struct RSDWeeklyScheduleObject : Codable, RSDSchedule {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case daysOfWeek, timeOfDayString = "timeOfDay"
     }
     
@@ -238,25 +238,7 @@ public class RSDWeeklyScheduleFormatter : Formatter {
 extension RSDWeeklyScheduleObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.daysOfWeek, .timeOfDayString]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .daysOfWeek:
-                if idx != 0 { return false }
-            case .timeOfDayString:
-                if idx != 1 { return false }
-            }
-        }
-        return keys.count == 2
+        return CodingKeys.allCases
     }
     
     static func _examples() -> [RSDWeeklyScheduleObject] {

--- a/Research/ResearchTests/Codable Tests/CodableTestObjects.swift
+++ b/Research/ResearchTests/Codable Tests/CodableTestObjects.swift
@@ -42,7 +42,7 @@ class BundleWrapper {
 
 struct TestResourceWrapper : RSDResourceTransformer, Codable {
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case resourceName, bundleIdentifier, classType
     }
     

--- a/Research/ResearchTests/Codable Tests/ExampleDecodableTests.swift
+++ b/Research/ResearchTests/Codable Tests/ExampleDecodableTests.swift
@@ -54,13 +54,6 @@ class ExampleDecodableTests: XCTestCase {
         let documentCreator = RSDDocumentCreator()
         for objectType in documentCreator.allCodableObjects {
             
-            let validKeys = objectType.validateAllKeysIncluded()
-            XCTAssertTrue(validKeys, "\(objectType)")
-
-            if !validKeys {
-                debugPrint(objectType)
-            }
-            
             let encoder = RSDFactory.shared.createJSONEncoder()
             let decoder = RSDFactory.shared.createJSONDecoder()
             
@@ -81,10 +74,6 @@ class ExampleDecodableTests: XCTestCase {
     func testAllDecodableObjects() {
         let documentCreator = RSDDocumentCreator()
         for objectType in documentCreator.allDecodableObjects {
-            
-            debugPrint(objectType)
-            let validKeys = objectType.validateAllKeysIncluded()
-            XCTAssertTrue(validKeys, "\(objectType)")
             
             let decoder = RSDFactory.shared.createJSONDecoder()
             

--- a/Research/ResearchTests/Codable Tests/RecordSampleLoggerTests.swift
+++ b/Research/ResearchTests/Codable Tests/RecordSampleLoggerTests.swift
@@ -50,7 +50,7 @@ struct TestRecord : RSDSampleRecord, RSDDelimiterSeparatedEncodable {
         return nil
     }
     
-    private enum CodingKeys : String, CodingKey {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
         case uptime, stepPath, x, y, z, label
     }
     


### PR DESCRIPTION
Swift 4.2 introduces the `CaseIterable` protocol and automatic synthesis of `Equatable` and `Hashable`. Use these features to remove a bunch of boilerplate code.