### PR TITLE
Serialization tweeks

### DIFF
--- a/Research/Research/RSDChoiceInputFieldObject.swift
+++ b/Research/Research/RSDChoiceInputFieldObject.swift
@@ -35,7 +35,8 @@ import Foundation
 
 /// `RSDChoiceInputFieldObject` is a concrete implementation of `RSDChoiceInputField` that subclasses `RSDInputFieldObject`
 /// to include a list of choices for a multiple choice or single choice input field.
-open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
+open class RSDChoiceInputFieldObject<T : Codable> : RSDInputFieldObject, RSDChoiceOptions {
+    public typealias Value = T
     
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case choices, defaultAnswer
@@ -94,9 +95,8 @@ open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
     /// - example:
     ///
     ///     ```
-    ///        // A JSON example where this is for a single choice input field that is a `decimal` base type
-    ///        // with a survey rule where the task should exit if the matching answer is `0`. This will
-    ///        // decode the choices as an array of `RSDChoiceObject<Double>` objects.
+    ///        // A JSON example where this is for a single choice input field that is a `decimal` base type.
+    ///        // This will decode the choices as an array of `RSDChoiceObject<Double>` objects.
     ///        let json = """
     ///            {
     ///                "identifier": "foo",
@@ -112,7 +112,6 @@ open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
     ///                                "detail" : "Is the magic number" },
     ///                             {  "text" : "None of the above",
     ///                                "isExclusive" : true }],
-    ///                "matchingAnswer": 0
     ///            }
     ///            """.data(using: .utf8)! // our data in native (JSON) format
     ///
@@ -190,35 +189,9 @@ open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
     public required init(from decoder: Decoder) throws {
         
         // Get the base data type
-        let dataType = try type(of: self).dataType(from: decoder)
-        
-        // decode the choices
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let choices: [RSDChoice]
-        switch dataType.baseType {
-        case .boolean:
-            choices = try container.decode([RSDChoiceObject<Bool>].self, forKey: .choices)
-            defaultAnswer = try container.decodeIfPresent(Bool.self, forKey: .defaultAnswer)
-        case .integer, .year:
-            choices = try container.decode([RSDChoiceObject<Int>].self, forKey: .choices)
-            defaultAnswer = try container.decodeIfPresent(Int.self, forKey: .defaultAnswer)
-        case .decimal, .duration:
-            choices = try container.decode([RSDChoiceObject<Double>].self, forKey: .choices)
-            defaultAnswer = try container.decodeIfPresent(Double.self, forKey: .defaultAnswer)
-        case .fraction:
-            choices = try container.decode([RSDChoiceObject<RSDFraction>].self, forKey: .choices)
-            defaultAnswer = try container.decodeIfPresent(RSDFraction.self, forKey: .defaultAnswer)
-        case .date:
-            choices = try container.decode([RSDChoiceObject<Date>].self, forKey: .choices)
-            defaultAnswer = try container.decodeIfPresent(Date.self, forKey: .defaultAnswer)
-        case .string:
-            choices = try container.decode([RSDChoiceObject<String>].self, forKey: .choices)
-            defaultAnswer = try container.decodeIfPresent(String.self, forKey: .defaultAnswer)
-        case .codable:
-            let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "`.codable` data type is not supported by this object.")
-            throw DecodingError.typeMismatch(Codable.self, context)
-        }
-        self.choices = choices
+        self.choices = try container.decode([RSDChoiceObject<Value>].self, forKey: .choices)
+        self.defaultAnswer = try container.decodeIfPresent(Value.self, forKey: .defaultAnswer)
         
         // call super
         try super.init(from: decoder)
@@ -263,8 +236,70 @@ open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
         return keys
     }
     
-    override class func examples() -> [[String : RSDJSONValue]] {
-        let jsonA: [String : RSDJSONValue] = [
+    static func exampleDictionary() -> [String : RSDJSONValue]? {
+        if Value.self == String.self {
+            return [
+                "identifier": "step3",
+                "prompt": "Step 3",
+                "type": "multipleChoice",
+                "defaultAnswer": "alpha",
+                "choices" : ["alpha", "beta", "charlie", "delta"]
+            ]
+        }
+        else if Value.self == Bool.self {
+            return [
+                "identifier": "heightLimit",
+                "prompt": "Are you tall?",
+                "type": "singleChoice.boolean",
+                "defaultAnswer": true,
+                "choices" : [[  "value" : true,
+                                "text" : "Yes"],
+                             [  "value" : false,
+                                "text" : "No"],
+                             [  "text" : "I don't know",
+                                "isExclusive" : true ]],
+            ]
+        }
+        else if Value.self == Int.self {
+            return [
+                "identifier": "happiness",
+                "prompt": "How happy are you?",
+                "type": "singleChoice.integer",
+                "defaultAnswer": 1,
+                "choices": [[
+                    "text": "delighted",
+                    "detail": "Nothing could be better!",
+                    "value": 1,
+                    "icon": "moodScale1"
+                    ],
+                            [
+                                "text": "good",
+                                "detail": "Life is good.",
+                                "value": 2,
+                                "icon": "moodScale2"
+                    ],
+                            [
+                                "text": "so-so",
+                                "detail": "Things are okay, I guess.",
+                                "value": 3,
+                                "icon": "moodScale3"
+                    ],
+                            [
+                                "text": "sad",
+                                "detail": "I'm feeling a bit down.",
+                                "value": 4,
+                                "icon": "moodScale4"
+                    ],
+                            [
+                                "text": "miserable",
+                                "detail": "I cry into my pillow every night.",
+                                "value": 5,
+                                "icon": "moodScale5"
+                    ]]
+            ]
+        }
+        else if Value.self == Double.self {
+            return [
                 "identifier": "foo",
                 "prompt": "Choose a number",
                 "type": "singleChoice.decimal",
@@ -279,105 +314,52 @@ open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
                                 "detail" : "Is the magic number" ],
                              [  "text" : "None of the above",
                                 "isExclusive" : true ]],
-                "matchingAnswer": 0
             ]
-        
-        let jsonB: [String : RSDJSONValue] = [
-              "identifier": "step3",
-              "prompt": "Step 3",
-              "type": "multipleChoice",
-              "defaultAnswer": "alpha",
-              "choices" : ["alpha", "beta", "charlie", "delta"]
-              ]
-        
-        let jsonC: [String : RSDJSONValue] = [
-            "identifier": "happiness",
-            "prompt": "How happy are you?",
-            "type": "singleChoice.integer",
-            "defaultAnswer": 1,
-            "choices": [[
-                        "text": "delighted",
-                        "detail": "Nothing could be better!",
-                        "value": 1,
-                        "icon": "moodScale1"
-                        ],
-                        [
-                        "text": "good",
-                        "detail": "Life is good.",
-                        "value": 2,
-                        "icon": "moodScale2"
-                        ],
-                        [
-                        "text": "so-so",
-                        "detail": "Things are okay, I guess.",
-                        "value": 3,
-                        "icon": "moodScale3"
-                        ],
-                        [
-                        "text": "sad",
-                        "detail": "I'm feeling a bit down.",
-                        "value": 4,
-                        "icon": "moodScale4"
-                        ],
-                        [
-                        "text": "miserable",
-                        "detail": "I cry into my pillow every night.",
-                        "value": 5,
-                        "icon": "moodScale5"
-                        ]]
+        }
+        else if Value.self == RSDFraction.self {
+            return [
+                "identifier": "happiness",
+                "prompt": "How happy are you?",
+                "type": "singleChoice.fraction",
+                "defaultAnswer": "3/5",
+                "choices": [[
+                    "text": "delighted",
+                    "detail": "Nothing could be better!",
+                    "value": "1/5",
+                    "icon": "moodScale1"
+                    ],
+                            [
+                                "text": "good",
+                                "detail": "Life is good.",
+                                "value": "2/5",
+                                "icon": "moodScale2"
+                    ],
+                            [
+                                "text": "so-so",
+                                "detail": "Things are okay, I guess.",
+                                "value": "3/5",
+                                "icon": "moodScale3"
+                    ],
+                            [
+                                "text": "sad",
+                                "detail": "I'm feeling a bit down.",
+                                "value": "4/5",
+                                "icon": "moodScale4"
+                    ],
+                            [
+                                "text": "miserable",
+                                "detail": "I cry into my pillow every night.",
+                                "value": "5/5",
+                                "icon": "moodScale5"
+                    ]
+                ]
             ]
-        
-        let jsonD: [String : RSDJSONValue] = [
-                "identifier": "heightLimit",
-                "prompt": "Are you tall?",
-                "type": "singleChoice.boolean",
-                "defaultAnswer": true,
-                "choices" : [[  "value" : true,
-                                "text" : "Yes"],
-                             [  "value" : false,
-                                "text" : "No"],
-                             [  "text" : "I don't know",
-                                "isExclusive" : true ]],
-            ]
-        
-        let jsonE: [String : RSDJSONValue] = [
-            "identifier": "happiness",
-            "prompt": "How happy are you?",
-            "type": "singleChoice.fraction",
-            "defaultAnswer": "3/5",
-            "choices": [[
-                            "text": "delighted",
-                            "detail": "Nothing could be better!",
-                            "value": "1/5",
-                            "icon": "moodScale1"
-                        ],
-                        [
-                            "text": "good",
-                            "detail": "Life is good.",
-                            "value": "2/5",
-                            "icon": "moodScale2"
-                        ],
-                        [
-                            "text": "so-so",
-                            "detail": "Things are okay, I guess.",
-                            "value": "3/5",
-                            "icon": "moodScale3"
-                        ],
-                        [
-                            "text": "sad",
-                            "detail": "I'm feeling a bit down.",
-                            "value": "4/5",
-                            "icon": "moodScale4"
-                        ],
-                        [
-                            "text": "miserable",
-                            "detail": "I cry into my pillow every night.",
-                            "value": "5/5",
-                            "icon": "moodScale5"
-                        ]
-            ]
-        ]
-        
-        return [jsonA, jsonB, jsonC, jsonD, jsonE]
+        }
+        return nil
+    }
+    
+    override class func examples() -> [[String : RSDJSONValue]] {
+        guard let dictionary = exampleDictionary() else { return [] }
+        return [dictionary]
     }
 }

--- a/Research/Research/RSDChoiceObject.swift
+++ b/Research/Research/RSDChoiceObject.swift
@@ -172,6 +172,8 @@ extension RSDChoiceObject : RSDDocumentableDecodableObject {
             return ["value": 1, "text": "one", "iconName": "iconOne", "detail": "The number one", "isExclusive": true]
         } else if Value.self == Double.self {
             return ["value": 1.2, "text": "one point two"]
+        } else if Value.self == RSDFraction.self {
+            return ["value": "1/2", "text": "one half"]
         }
         return nil
     }

--- a/Research/Research/RSDComparable.swift
+++ b/Research/Research/RSDComparable.swift
@@ -146,7 +146,12 @@ extension RSDComparable {
         // Otherwise, look at the base type
         switch answerType.baseType {
         case .string:
-            return "\(answerValue)" as NSString
+            if let comparableValue = answerValue as? CustomStringConvertible {
+                return comparableValue.description
+            }
+            else {
+                return "\(answerValue)" as NSString
+            }
         case .date:
             if let date = answerValue as? NSDate {
                 return date

--- a/Research/Research/RSDDocumentable.swift
+++ b/Research/Research/RSDDocumentable.swift
@@ -81,12 +81,6 @@ public struct RSDDocumentCreator {
             RSDWeekday.self,
             ]
         
-        #if os(iOS)
-            let iOSEnums: [RSDDocumentableIntEnum.Type] = [
-                ]
-            allEnums.append(contentsOf: iOSEnums)
-        #endif
-        
         return allEnums
     }()
     
@@ -148,6 +142,7 @@ public struct RSDDocumentCreator {
         RSDComparableSurveyRuleObject<Date>.self,
         RSDComparableSurveyRuleObject<Double>.self,
         RSDComparableSurveyRuleObject<Int>.self,
+        RSDComparableSurveyRuleObject<RSDFraction>.self,
         RSDUIStepObject.self,
         RSDActiveUIStepObject.self,
         RSDFormUIStepObject.self,
@@ -157,7 +152,12 @@ public struct RSDDocumentCreator {
         RSDStepTransformerObject.self,
         RSDInputFieldObject.self,
         RSDDetailInputFieldObject.self,
-        RSDChoiceInputFieldObject.self,
+        RSDChoiceInputFieldObject<Bool>.self,
+        RSDChoiceInputFieldObject<String>.self,
+        RSDChoiceInputFieldObject<Date>.self,
+        RSDChoiceInputFieldObject<Double>.self,
+        RSDChoiceInputFieldObject<Int>.self,
+        RSDComparableSurveyRuleObject<RSDFraction>.self,
         RSDMultipleComponentInputFieldObject.self,
         RSDSchemaInfoObject.self,
         RSDConditionalStepNavigatorObject.self,

--- a/Research/Research/RSDFactory.swift
+++ b/Research/Research/RSDFactory.swift
@@ -96,6 +96,7 @@ open class RSDFactory {
     ///     - schemaInfo: The schema info for the task.
     /// - returns: The decoded task.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDTaskResourceTransformer`
     open func decodeTask(with resourceTransformer: RSDResourceTransformer, taskIdentifier: String? = nil, schemaInfo: RSDSchemaInfo? = nil) throws -> RSDTask {
         let (data, type) = try resourceTransformer.resourceData()
         return try decodeTask(with: data,
@@ -117,6 +118,7 @@ open class RSDFactory {
     ///     - schemaInfo:      The schema info for the task.
     /// - returns: The decoded task.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDTaskResourceTransformer`
     open func decodeTask(with data: Data, resourceType: RSDResourceType, typeName: String? = nil, taskIdentifier: String? = nil, schemaInfo: RSDSchemaInfo? = nil, bundle: Bundle? = nil) throws -> RSDTask {
         let decoder = try createDecoder(for: resourceType, taskIdentifier: taskIdentifier, schemaInfo: schemaInfo, bundle: bundle)
         let task = try decoder.decode(RSDTaskObject.self, from: data)
@@ -141,6 +143,7 @@ open class RSDFactory {
     /// - parameter decoder: The decoder to use to instantiate the object.
     /// - returns: The task info created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDTaskGroupObject`
     open func decodeTaskInfo(from decoder: Decoder) throws -> RSDTaskInfo {
         return try RSDTaskInfoObject(from: decoder)
     }
@@ -153,6 +156,7 @@ open class RSDFactory {
     /// - parameter decoder: The decoder to use to instantiate the object.
     /// - returns: The schema info created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDTaskResultObject`
     open func decodeSchemaInfo(from decoder: Decoder) throws -> RSDSchemaInfo {
         return try RSDSchemaInfoObject(from: decoder)
     }
@@ -197,6 +201,7 @@ open class RSDFactory {
     /// - parameter decoder: The decoder to use to instantiate the object.
     /// - returns: The step navigator created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDTaskObject`
     open func decodeStepNavigator(from decoder: Decoder) throws -> RSDStepNavigator {
         guard let name = try typeName(from: decoder) else {
             return try RSDConditionalStepNavigatorObject(from: decoder)
@@ -225,6 +230,7 @@ open class RSDFactory {
     /// - parameter container: The unkeyed container with the steps.
     /// - returns: An array of the steps.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDConditionalStepNavigatorObject`, `RSDSectionStepObject`
     public func decodeSteps(from container: UnkeyedDecodingContainer) throws -> [RSDStep] {
         var steps : [RSDStep] = []
         var stepsContainer = container
@@ -321,6 +327,7 @@ open class RSDFactory {
     /// - parameter decoder: The decoder to use to instantiate the object.
     /// - returns: The step (if any) created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDFormUIStepObject`
     open func decodeInputField(from decoder: Decoder) throws -> RSDInputField? {
         let dataType = try RSDInputFieldObject.dataType(from: decoder)
         let inputField = try decodeInputField(from: decoder, with: dataType)
@@ -408,6 +415,7 @@ open class RSDFactory {
     ///     - dataType: The data type associated with this instance.
     /// - returns: An array of survey rules.
     /// - throws: `DecodingError`
+    /// - seealso: `RSDInputFieldObject`
     open func decodeSurveyRules(from rulesContainer: UnkeyedDecodingContainer, for dataType: RSDFormDataType) throws -> [RSDSurveyRule] {
         var container = rulesContainer
         var surveyRules = [RSDSurveyRule]()
@@ -460,6 +468,7 @@ open class RSDFactory {
     ///     - dataType: The data type associated with this instance.
     /// - returns: An appropriate instance of `RSDRange`.
     /// - throws: `DecodingError`
+    /// - seealso: `RSDInputFieldObject`
     open func decodeRange(from decoder: Decoder, for dataType: RSDFormDataType) throws -> RSDRange? {
         switch dataType.baseType {
         case .integer, .decimal, .fraction:
@@ -494,6 +503,7 @@ open class RSDFactory {
     /// - parameter decoder: The decoder to use to instantiate the object.
     /// - returns: The text validator created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDTextFieldOptionsObject`
     open func decodeTextValidator(from decoder: Decoder) throws -> RSDTextValidator? {
         return try RSDRegExValidatorObject(from: decoder)
     }
@@ -507,6 +517,7 @@ open class RSDFactory {
     /// - parameter decoder: The decoder to use to instantiate the object.
     /// - returns: The number formatter created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDNumberRangeObject`
     open func decodeNumberFormatter(from decoder: Decoder) throws -> NumberFormatter {
         return try NumberFormatter(from: decoder)
     }
@@ -522,6 +533,7 @@ open class RSDFactory {
     ///     - objectType: The object type to which this action should be cast.
     /// - returns: The UI action created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDUIActionHandlerObject`
     open func decodeUIAction(from decoder:Decoder, for actionType: RSDUIActionType) throws -> RSDUIAction {
         guard let str = try? self.typeName(from: decoder), let typeName = str else {
             let obj = try _deprecated_decodeUIAction(from: decoder, for: actionType)
@@ -584,6 +596,7 @@ open class RSDFactory {
     ///     - decoder: The decoder to use to instantiate the object.
     /// - returns: The UI color theme created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDUIStepObject`
     open func decodeColorThemeElement(from decoder:Decoder) throws -> RSDColorThemeElement? {
         return try _decodeResource(RSDColorThemeElementObject.self, from: decoder)
     }
@@ -594,6 +607,7 @@ open class RSDFactory {
     ///     - decoder: The decoder to use to instantiate the object.
     /// - returns: The UI view theme created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDUIStepObject`
     open func decodeViewThemeElement(from decoder:Decoder) throws -> RSDViewThemeElement? {
         return try _decodeResource(RSDViewThemeElementObject.self, from: decoder)
     }
@@ -604,6 +618,7 @@ open class RSDFactory {
     ///     - decoder: The decoder to use to instantiate the object.
     /// - returns: The UI image theme created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDUIStepObject`
     open func decodeImageThemeElement(from decoder:Decoder) throws -> RSDImageThemeElement? {
         guard let str = try? self.typeName(from: decoder), let typeName = str else {
             let obj = try _deprecated_decodeImageThemeElement(from: decoder)
@@ -657,6 +672,7 @@ open class RSDFactory {
     /// - parameter decoder: The decoder to use to instantiate the object.
     /// - returns: The configuration (if any) created from this decoder.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDTaskObject`, `RSDSectionStepObject`
     open func decodeAsyncActionConfiguration(from decoder:Decoder) throws -> RSDAsyncActionConfiguration? {
         guard let typeName = try typeName(from: decoder) else {
             let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "\(self) does not support decoding an async action without a `type` key defining a value for the the class name.")
@@ -700,6 +716,7 @@ open class RSDFactory {
     /// - parameter container: The unkeyed container with the results.
     /// - returns: An array of the results.
     /// - throws: `DecodingError` if the object cannot be decoded.
+    /// - seealso: `RSDTaskResultObject`, `RSDCollectionResultObject`
     public func decodeResults(from container: UnkeyedDecodingContainer) throws -> [RSDResult] {
         var results : [RSDResult] = []
         var mutableContainer = container
@@ -789,6 +806,7 @@ open class RSDFactory {
         return rsd_ISO8601TimestampFormatter
     }
     
+    /// The default coding strategy to use for non-conforming elements.
     open var nonConformingCodingStrategy: (positiveInfinity: String, negativeInfinity: String, nan: String)
         = ("Infinity", "-Infinity", "NaN")
 

--- a/Research/Research/RSDFactory.swift
+++ b/Research/Research/RSDFactory.swift
@@ -382,14 +382,13 @@ open class RSDFactory {
     
     // MARK: Survey rules
     
-    /// Overridable function for decoding a list of survey rules from the decoder a given input field.
-    /// The default implementation will instantiate a list of `RSDComparableSurveyRuleObject` instances
+    /// Overridable function for decoding a list of survey rules from an unkeyed container for a given data
+    /// type. The default implementation will instantiate a list of `RSDComparableSurveyRuleObject` instances
     /// appropriate to the `BaseType` of the given data type.
     ///
     /// - example:
     ///
-    /// The following will decode as an array of `[RSDComparableSurveyRuleObject<Int>]` because of the
-    /// "surveyRules" key.
+    /// The following will decode the "surveyRules" key as an array of `[RSDComparableSurveyRuleObject<Int>]`.
     ///
     ///     ````
     ///        {

--- a/Research/Research/RSDFactory.swift
+++ b/Research/Research/RSDFactory.swift
@@ -344,7 +344,24 @@ open class RSDFactory {
                 return try RSDMultipleComponentInputFieldObject(from: decoder)
                 
             case .multipleChoice, .singleChoice:
-                return try RSDChoiceInputFieldObject(from: decoder)
+                switch dataType.baseType {
+                case .boolean:
+                    return try RSDChoiceInputFieldObject<Bool>(from: decoder)
+                case .string:
+                    return try RSDChoiceInputFieldObject<String>(from: decoder)
+                case .date:
+                    return try RSDChoiceInputFieldObject<Date>(from: decoder)
+                case .decimal, .duration:
+                    return try RSDChoiceInputFieldObject<Double>(from: decoder)
+                case .fraction:
+                    return try RSDChoiceInputFieldObject<RSDFraction>(from: decoder)
+                case .integer, .year:
+                    return try RSDChoiceInputFieldObject<Int>(from: decoder)
+                case .codable:
+                    let codingPath = decoder.codingPath
+                    let context = DecodingError.Context(codingPath: codingPath, debugDescription: "Input field choices for a .codable data type are not supported by this factory: \(self).")
+                    throw DecodingError.typeMismatch(Codable.self, context)
+                }
             }
             
         case .detail(_):
@@ -493,7 +510,7 @@ open class RSDFactory {
     open func decodeNumberFormatter(from decoder: Decoder) throws -> NumberFormatter {
         return try NumberFormatter(from: decoder)
     }
-    
+
     
     // MARK: UI action factory
     

--- a/Research/Research/RSDInputFieldObject.swift
+++ b/Research/Research/RSDInputFieldObject.swift
@@ -348,11 +348,11 @@ open class RSDInputFieldObject : RSDSurveyInputField, RSDMutableInputField, RSDC
                          "matchingAnswer" : 0]
                 
             case .duration:
-                return [ "identifier" : "timeIntervalExample",
-                         "prompt" : "This is a time interval input field",
+                return [ "identifier" : "durationExample",
+                         "prompt" : "This is a duration input field",
                          "type" : "duration",
                          "uiHint" : "picker",
-                         "placeholderText" : "select a time interval",
+                         "placeholderText" : "Select a duration",
                          "range" : [ "minimumValue" : 0,
                                      "maximumValue" : 26,
                                      "unit" : "minute"]]

--- a/Research/ResearchTests/Codable Tests/CodableInputFieldObjectTests.swift
+++ b/Research/ResearchTests/Codable Tests/CodableInputFieldObjectTests.swift
@@ -177,7 +177,7 @@ class CodableInputFieldObjectTests: XCTestCase {
         
         do {
             
-            let object = try decoder.decode(RSDChoiceInputFieldObject.self, from: json)
+            let object = try decoder.decode(RSDChoiceInputFieldObject<String>.self, from: json)
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.dataType, .collection(.multipleChoice, .string))
@@ -228,7 +228,7 @@ class CodableInputFieldObjectTests: XCTestCase {
         
         do {
             
-            let object = try decoder.decode(RSDChoiceInputFieldObject.self, from: json)
+            let object = try decoder.decode(RSDChoiceInputFieldObject<Int>.self, from: json)
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.inputPrompt, "Text")
@@ -289,7 +289,7 @@ class CodableInputFieldObjectTests: XCTestCase {
         
         do {
             
-            let object = try decoder.decode(RSDChoiceInputFieldObject.self, from: json)
+            let object = try decoder.decode(RSDChoiceInputFieldObject<RSDFraction>.self, from: json)
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.inputPrompt, "Text")

--- a/Research/ResearchTests/Codable Tests/CodableStepObjectTests.swift
+++ b/Research/ResearchTests/Codable Tests/CodableStepObjectTests.swift
@@ -394,7 +394,7 @@ class CodableStepObjectTests: XCTestCase {
                 XCTAssertEqual(object.inputFields[0].dataType, .base(.date))
                 XCTAssertEqual(object.inputFields[1].dataType, .base(.integer))
                 XCTAssertEqual(object.inputFields[2].dataType, .collection(.multipleChoice, .string))
-                XCTAssertNotNil(object.inputFields[2] as? RSDChoiceInputFieldObject)
+                XCTAssertNotNil(object.inputFields[2] as? RSDChoiceInputFieldObject<String>)
             }
             
             if let detail = object.inputFields.last as? RSDDetailInputFieldObject {
@@ -432,7 +432,7 @@ class CodableStepObjectTests: XCTestCase {
             XCTAssertEqual(object.title, "Step 3")
             XCTAssertEqual(object.inputFields.count, 1)
             XCTAssertEqual(object.inputFields.first?.dataType, .collection(.multipleChoice, .string))
-            XCTAssertNotNil(object.inputFields.first as? RSDChoiceInputFieldObject)
+            XCTAssertNotNil(object.inputFields.first as? RSDChoiceInputFieldObject<String>)
             
         } catch let err {
             XCTFail("Failed to decode/encode object: \(err)")


### PR DESCRIPTION
This includes some refactoring of the input fields to better match the way the factory decodes `type` elsewhere in the code. 

TODO:
1. Better consolidation and documentation of the JSON schemas used for serialization in the frameworks.
2. Refactor to allow using different factories to decode model objects.
 