### PR TITLE
Add a color rule for displaying a severity scale using color

### DIFF
--- a/Research/Research/RSDColorRules.swift
+++ b/Research/Research/RSDColorRules.swift
@@ -72,6 +72,7 @@ open class RSDColorRules  {
         set {
             guard newValue != nil else { return }
             _palette = newValue
+            self.severityColorScale.grayScale = newValue.grayScale
         }
     }
     private var _palette: RSDColorPalette
@@ -448,4 +449,68 @@ open class RSDColorRules  {
     open func textFieldUnderline(on background: RSDColorTile) -> RSDColor {
         return self.palette.accent.normal.color
     }
+    
+    
+    // MARK: Severity colors used for showing a scale from "normal - severe"
+    
+    /// The severity color scale to use for buttons and graphics in this app.
+    open var severityColorScale : RSDSeverityColorScale = RSDSeverityColorScale()
+}
+
+/// Color rules for defining a scale for a series of colors.
+open class RSDSeverityColorScale {
+    
+    /// A numeric scale of 0-3 for the severity of a symptom or condition.
+    public enum Scale : Int, Codable {
+        case none = 0, mild, moderate, severe
+    }
+    
+    /// The color palette that backs this rule.
+    public var grayScale = RSDStudyConfiguration.shared.colorPalette.grayScale
+    
+    /// The fill color of the button representing this scale value.
+    /// - parameters:
+    ///     - value: The scale value.
+    ///     - isSelected: Whether or not the button is selected.
+    /// - returns: The fill color for the button.
+    open func fill(for value: Int, isSelected: Bool) -> RSDColor {
+        guard isSelected, value >= 0, value < severityFill.count
+            else {
+                return grayScale.white.color
+        }
+        return severityFill[value]
+    }
+    
+    /// The stroke color of the button representing this scale value.
+    /// - parameters:
+    ///     - value: The scale value.
+    ///     - isSelected: Whether or not the button is selected.
+    /// - returns: The stroke color for the button.
+    open func stroke(for value: Int, isSelected: Bool) -> RSDColor {
+        guard isSelected, value >= 0, value < severityFill.count
+            else {
+                return grayScale.veryLightGray.color
+        }
+        return severityStroke[value]
+    }
+    
+    /// The fill colors for the severity toggle.
+    let severityFill: [RSDColor] = {
+        return [
+            RSDColor(red: 232 / 255.0, green: 250.0 / 255.0, blue: 232.0 / 255.0, alpha: 1),
+            RSDColor(red: 255.0 / 255.0, green: 240.0 / 255.0, blue: 212.0 / 255.0, alpha: 1),
+            RSDColor(red: 255.0 / 255.0, green: 232.0 / 255.0, blue: 214.0 / 255.0, alpha: 1),
+            RSDColor(red: 252.0 / 255.0, green: 233.0 / 255.0, blue: 230.0 / 255.0, alpha: 1)
+        ]
+    }()
+    
+    /// The stroke colors for the severity toggle.
+    let severityStroke: [RSDColor] = {
+        return [
+            RSDColor(red: 192.0 / 255.0, green: 235.0 / 255.0, blue: 192.0 / 255.0, alpha: 1),
+            RSDColor(red: 255.0 / 255.0, green: 226.0 / 255.0, blue: 173.0 / 255.0, alpha: 1),
+            RSDColor(red: 250.0 / 255.0, green: 207.0 / 255.0, blue: 175.0 / 255.0, alpha: 1),
+            RSDColor(red: 255.0 / 255.0, green: 197.0 / 255.0, blue: 189.0 / 255.0, alpha: 1)
+        ]
+    }()
 }

--- a/Research/Research/RSDColorRules.swift
+++ b/Research/Research/RSDColorRules.swift
@@ -340,7 +340,7 @@ open class RSDColorRules  {
             
             if background == self.palette.grayScale.white {
                 inner = isSelected ? self.palette.primary.dark : self.palette.grayScale.white
-                border = isSelected ? self.palette.primary.normal.color : self.palette.grayScale.veryLightGray.color
+                border = isSelected ? self.palette.primary.normal.color : self.palette.grayScale.lightGray.color
             }
             else {
                 inner = isSelected ? self.palette.secondary.normal : self.palette.grayScale.white
@@ -489,7 +489,7 @@ open class RSDSeverityColorScale {
     open func stroke(for value: Int, isSelected: Bool) -> RSDColor {
         guard isSelected, value >= 0, value < severityFill.count
             else {
-                return grayScale.veryLightGray.color
+                return grayScale.lightGray.color
         }
         return severityStroke[value]
     }

--- a/ResearchUI/ResearchUI/iOS/Views/RSDCheckmarkView.swift
+++ b/ResearchUI/ResearchUI/iOS/Views/RSDCheckmarkView.swift
@@ -465,7 +465,7 @@ fileprivate class RSDCheckboxButtonView : UIView, RSDViewDesignable {
 @IBDesignable
 fileprivate class UncheckedView : UIView {
     
-    fileprivate var borderColor: UIColor = RSDStudyConfiguration.shared.colorPalette.grayScale.veryLightGray.color {
+    fileprivate var borderColor: UIColor = RSDStudyConfiguration.shared.colorPalette.grayScale.lightGray.color {
         didSet {
             self.layer.borderColor = borderColor.cgColor
         }

--- a/ResearchUI/ResearchUI/iOS/Views/RSDStepChoiceCell.swift
+++ b/ResearchUI/ResearchUI/iOS/Views/RSDStepChoiceCell.swift
@@ -34,21 +34,12 @@
 import UIKit
 
 
-/// `RSDStepChoiceCell` is the base implementation for a selection table view cell of a form step.
-@IBDesignable public class RSDStepChoiceCell: RSDTableViewCell {
+/// `RSDSelectionTableViewCell` is the base implementation for a selection table view cell.
+@IBDesignable open class RSDSelectionTableViewCell: RSDTableViewCell {
     
-    @IBOutlet public var titleLabel: UILabel!
-    @IBOutlet public var detailLabel: UILabel!
+    @IBOutlet public var titleLabel: UILabel?
+    @IBOutlet public var detailLabel: UILabel?
     @IBOutlet public var separatorLine: UIView?
-    
-    override public var tableItem: RSDTableItem! {
-        didSet {
-            guard let item = tableItem as? RSDChoiceTableItem else { return }
-            titleLabel.text = item.choice.text
-            detailLabel.text = item.choice.detail
-            isSelected = item.selected
-        }
-    }
     
     open override var isSelected: Bool {
         didSet {
@@ -66,13 +57,13 @@ import UIKit
         
         contentView.backgroundColor = contentTile.color
         separatorLine?.backgroundColor = designSystem.colorRules.separatorLine
-        titleLabel.textColor = designSystem.colorRules.textColor(on: contentTile, for: titleTextType)
-        titleLabel.font = designSystem.fontRules.font(for: titleTextType, compatibleWith: traitCollection)
+        titleLabel?.textColor = designSystem.colorRules.textColor(on: contentTile, for: titleTextType)
+        titleLabel?.font = designSystem.fontRules.font(for: titleTextType, compatibleWith: traitCollection)
         detailLabel?.textColor = designSystem.colorRules.textColor(on: contentTile, for: detailTextType)
-        detailLabel.font = designSystem.fontRules.font(for: detailTextType, compatibleWith: traitCollection)
+        detailLabel?.font = designSystem.fontRules.font(for: detailTextType, compatibleWith: traitCollection)
     }
     
-    override public func setDesignSystem(_ designSystem: RSDDesignSystem, with background: RSDColorTile) {
+    override open func setDesignSystem(_ designSystem: RSDDesignSystem, with background: RSDColorTile) {
         super.setDesignSystem(designSystem, with: background)
         updateColorsAndFonts()
     }
@@ -85,26 +76,26 @@ import UIKit
         
         // Add the title label
         titleLabel = UILabel()
-        contentView.addSubview(titleLabel)
+        contentView.addSubview(titleLabel!)
         
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.numberOfLines = 0
-        titleLabel.textAlignment = .left
-        titleLabel.rsd_alignToSuperview([.leading], padding: kTableSideMargin)
-        titleLabel.rsd_align([.trailing], .lessThanOrEqual, to: contentView, [.trailing], padding: kTableSideMargin, priority: .required)
-        titleLabel.rsd_alignToSuperview([.top], padding: kTableTopMargin, priority: UILayoutPriority(rawValue: 700))
+        titleLabel!.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel!.numberOfLines = 0
+        titleLabel!.textAlignment = .left
+        titleLabel!.rsd_alignToSuperview([.leading], padding: kTableSideMargin)
+        titleLabel!.rsd_align([.trailing], .lessThanOrEqual, to: contentView, [.trailing], padding: kTableSideMargin, priority: .required)
+        titleLabel!.rsd_alignToSuperview([.top], padding: kTableTopMargin, priority: UILayoutPriority(rawValue: 700))
         
         // Add the detail label
         detailLabel = UILabel()
-        contentView.addSubview(detailLabel)
+        contentView.addSubview(detailLabel!)
         
-        detailLabel.translatesAutoresizingMaskIntoConstraints = false
-        detailLabel.numberOfLines = 0
-        detailLabel.textAlignment = .left
-        detailLabel.rsd_alignToSuperview([.leading], padding: kTableSideMargin)
-        detailLabel.rsd_align([.trailing], .lessThanOrEqual, to: contentView, [.trailing], padding: kTableSideMargin, priority: .required)
-        detailLabel.rsd_alignToSuperview([.bottom], padding: kTableBottomMargin)
-        detailLabel.rsd_alignBelow(view: titleLabel, padding: 2.0)
+        detailLabel!.translatesAutoresizingMaskIntoConstraints = false
+        detailLabel!.numberOfLines = 0
+        detailLabel!.textAlignment = .left
+        detailLabel!.rsd_alignToSuperview([.leading], padding: kTableSideMargin)
+        detailLabel!.rsd_align([.trailing], .lessThanOrEqual, to: contentView, [.trailing], padding: kTableSideMargin, priority: .required)
+        detailLabel!.rsd_alignToSuperview([.bottom], padding: kTableBottomMargin)
+        detailLabel!.rsd_alignBelow(view: titleLabel!, padding: 2.0)
         
         // Add the line separator
         separatorLine = UIView()
@@ -127,5 +118,19 @@ import UIKit
     
     open override func awakeFromNib() {
         super.awakeFromNib()
+    }
+}
+
+/// `RSDStepChoiceCell` is a custom implementationn of a selection table cell to use for choice selection
+/// from a list of choices.
+@IBDesignable public class RSDStepChoiceCell: RSDSelectionTableViewCell {
+    
+    override public var tableItem: RSDTableItem! {
+        didSet {
+            guard let item = tableItem as? RSDChoiceTableItem else { return }
+            titleLabel?.text = item.choice.text
+            detailLabel?.text = item.choice.detail
+            isSelected = item.selected
+        }
     }
 }


### PR DESCRIPTION
This is used in mPower to display the history and initial selection by associating a color with the severity of a symptom or medical condition.

I decided to use a class that hangs off of the color rules (and may move to using the same design for other logical groupings of rules as well). This was in part b/c the colors aren't officially part of the design system (yet) and they are hard coded. Partly b/c the factory for the rules is getting a bit prohibitively long. :)