### PR TITLE
Zero out the motion sensor and video timestamp

### DIFF
--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateRecorder.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateRecorder.swift
@@ -94,7 +94,14 @@ public class CRFHeartRateRecorder : RSDSampleRecorder, CRFHeartRateVideoProcesso
             else {
                 return nil
         }
-        let startTime = self.clock.startSystemUptime + 30
+        let timestampOffset: Double = {
+            guard let videoUptime = self._videoProcessor?.startSystemUptime
+                else {
+                    return 0.0
+            }
+            return videoUptime - self.clock.startSystemUptime
+        }()
+        let startTime = timestampOffset + 30
         let age = Double(Calendar(identifier: .iso8601).component(.year, from: Date()) - birthYear)
         return sampleProcessor.vo2Max(sex: sex, age: age, startTime: startTime)
     }

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateRecorder.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateRecorder.swift
@@ -99,7 +99,7 @@ public class CRFHeartRateRecorder : RSDSampleRecorder, CRFHeartRateVideoProcesso
                 else {
                     return 0.0
             }
-            return videoUptime - self.clock.startSystemUptime
+            return self.clock.startSystemUptime - videoUptime
         }()
         let startTime = timestampOffset + 30
         let age = Double(Calendar(identifier: .iso8601).component(.year, from: Date()) - birthYear)

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateVideoProcessor.h
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateVideoProcessor.h
@@ -60,6 +60,7 @@ struct CRFPixelSample {
 @interface CRFHeartRateVideoProcessor : NSObject
 
 @property (nonatomic, readonly) int frameRate;
+@property (nonatomic, readonly) double startSystemUptime;
 
 @property (nonatomic, nullable, readonly) NSURL *videoURL;
 

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateVideoProcessor.m
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateVideoProcessor.m
@@ -69,6 +69,7 @@ const long CRFRedStdDevThreshold = 15.0;
         _delegateCallbackQueue = queue;
         _processingQueue = dispatch_queue_create("org.sagebase.CRF.heartRateSample.processing", DISPATCH_QUEUE_SERIAL);
         _frameRate = frameRate;
+        _startSystemUptime = [[NSProcessInfo processInfo] systemUptime];
     }
     return self;
 }
@@ -182,7 +183,7 @@ const long CRFRedStdDevThreshold = 15.0;
     
     // Create a struct to return the pixel average
     struct CRFPixelSample sample;
-    sample.presentationTimestamp = (double)(pts.value) / (double)(pts.timescale);
+    sample.presentationTimestamp = (double)(pts.value) / (double)(pts.timescale) - self.startSystemUptime;
     sample.red = r / 255.0;
     sample.green = g / 255.0;
     sample.blue = b / 255.0;

--- a/Research/Research/RSDClock.swift
+++ b/Research/Research/RSDClock.swift
@@ -106,6 +106,12 @@ public class RSDClock {
         return marker.clock + (systemUptime - marker.system)
     }
     
+    /// Get the clock uptime for a system awake time.
+    public func zeroRelativeTime(to systemUptime: TimeInterval) -> TimeInterval {
+        let marker = timeMarkers.last { systemUptime >= $0.system } ?? timeMarkers.first!
+        return (systemUptime - marker.system) + (marker.clock - timeMarkers[0].clock)
+    }
+    
     /// Clock time.
     public static func uptime() -> TimeInterval {
         var uptime = timespec()

--- a/Research/Research/RSDMotionRecorder.swift
+++ b/Research/Research/RSDMotionRecorder.swift
@@ -395,7 +395,7 @@ public struct RSDMotionRecord : RSDSampleRecord, RSDDelimiterSeparatedEncodable 
     public init(stepPath: String, data: RSDVectorData, referenceClock: RSDClock? = nil) {
         
         self.uptime = referenceClock?.relativeUptime(to: data.timestamp)
-        self.timestamp = data.timestamp
+        self.timestamp = referenceClock?.zeroRelativeTime(to: data.timestamp) ?? data.timestamp
         self.stepPath = stepPath
         self.timestampDate = nil
         self.heading = nil
@@ -455,7 +455,7 @@ public struct RSDMotionRecord : RSDSampleRecord, RSDDelimiterSeparatedEncodable 
         }
         
         self.uptime = referenceClock?.relativeUptime(to: data.timestamp)
-        self.timestamp = data.timestamp
+        self.timestamp = referenceClock?.zeroRelativeTime(to: data.timestamp) ?? data.timestamp
         self.stepPath = stepPath
         self.timestampDate = nil
         self.sensorType = sensorType
@@ -577,7 +577,7 @@ extension RSDMotionRecord : RSDDocumentableCodableObject {
     static func examples() -> [Encodable] {
         
         let uptime = RSDClock.uptime()
-        let timestamp = ProcessInfo.processInfo.systemUptime
+        let timestamp = 0.0
         
         let gyro = RSDMotionRecord(uptime: uptime, timestamp: timestamp, stepPath: "step1", timestampDate: nil, sensorType: .gyro, eventAccuracy: nil, referenceCoordinate: nil, heading: nil, x: 0.064788818359375, y: -0.1324615478515625, z: -0.9501953125, w: nil)
         let accelerometer = RSDMotionRecord(uptime: uptime, timestamp: timestamp, stepPath: "step1", timestampDate: nil, sensorType: .accelerometer, eventAccuracy: nil, referenceCoordinate: nil, heading: nil, x: 0.064788818359375, y: -0.1324615478515625, z: -0.9501953125, w: nil)

--- a/Research/Research/RSDSampleRecorder.swift
+++ b/Research/Research/RSDSampleRecorder.swift
@@ -63,6 +63,12 @@ public protocol RSDSampleRecord : Codable {
     /// On Apple devices, this is the timestamp used to mark sensors that run in the foreground only such as
     /// video processing and motion sensors.
     ///
+    /// syoung 04/24/2019 Per request from Sage Bionetworks' research scientists, this timestamp is "zeroed"
+    /// to when the recorder is started. It should be calculated by offsetting the
+    /// `ProcessInfo.processInfo.systemUptime` from the monotonic clock time to account for gaps in the
+    /// sampling due to the application becoming inactive. For example, if the participant accepts a phone
+    /// call while the recorder is running.
+    ///
     /// -seealso: `ProcessInfo.processInfo.systemUptime`
     var timestamp: TimeInterval? { get }
 }
@@ -629,7 +635,7 @@ open class RSDSampleRecorder : NSObject, RSDAsyncAction {
     /// Write a marker to each logging file.
     private func _writeMarkers(step: RSDStep?, taskViewModel: RSDPathComponent) {
         let uptime = RSDClock.uptime()
-        let timestamp = ProcessInfo.processInfo.systemUptime
+        let timestamp = clock.zeroRelativeTime(to: ProcessInfo.processInfo.systemUptime)
         let date = Date()
         self.loggerQueue.async {
             

--- a/Research/ResearchTests/ModelObject Tests/ClockTests.swift
+++ b/Research/ResearchTests/ModelObject Tests/ClockTests.swift
@@ -65,6 +65,10 @@ class ClockTests: XCTestCase {
         let testTime = systemTime + offset
         let testTimeActual = clock.relativeUptime(to: testTime)
         XCTAssertEqual(testTimeExpected, testTimeActual, accuracy:0.0001)
+        
+        let zeroTimeActual = clock.zeroRelativeTime(to: testTime)
+        let zeroTimeEspected = testTimeActual - clockTime
+        XCTAssertEqual(zeroTimeEspected, zeroTimeActual, accuracy:0.0001)
     }
     
     func testSleepOffset_BeforeStart() {
@@ -86,6 +90,10 @@ class ClockTests: XCTestCase {
         let testTime = systemTime + offset
         let testTimeActual = clock.relativeUptime(to: testTime)
         XCTAssertEqual(testTimeExpected, testTimeActual, accuracy:0.0001)
+        
+        let zeroTimeActual = clock.zeroRelativeTime(to: testTime)
+        let zeroTimeEspected = testTimeActual - clockTime
+        XCTAssertEqual(zeroTimeEspected, zeroTimeActual, accuracy:0.0001)
     }
     
     func testSleepOffset_AfterSleep() {
@@ -104,9 +112,45 @@ class ClockTests: XCTestCase {
         clock.addTimeMarkers(wakeClock, wakeSystem)
         
         let offsetAfter: TimeInterval = 10 * 60
-        let testTimeAfterExpected = clockTime + offsetAfter
-        let testTimeAfter = systemTime + offsetAfter - sleepOffset
-        let testTimeAfterActual = clock.relativeUptime(to: testTimeAfter)
-        XCTAssertEqual(testTimeAfterExpected, testTimeAfterActual, accuracy:0.0001)
+        let testTimeExpected = clockTime + offsetAfter
+        let testTime = systemTime + offsetAfter - sleepOffset
+        let testTimeActual = clock.relativeUptime(to: testTime)
+        XCTAssertEqual(testTimeExpected, testTimeActual, accuracy:0.0001)
+        
+        let zeroTimeActual = clock.zeroRelativeTime(to: testTime)
+        let zeroTimeEspected = testTimeActual - clockTime
+        XCTAssertEqual(zeroTimeEspected, zeroTimeActual, accuracy:0.0001)
+    }
+    
+    func testSleepOffset_AfterSleepX2() {
+        
+        let start: TimeInterval = -10 * 60
+        let date = Date().addingTimeInterval(start)
+        let clockTime = RSDClock.uptime()
+        let systemTime = ProcessInfo.processInfo.systemUptime
+        
+        let clock = RSDClock(clock: clockTime, system: systemTime, date: date)
+        
+        let sleepOffset1: TimeInterval = 5 * 60
+        let wakeAt1: TimeInterval = 8 * 60
+        let wakeClock1 = clockTime + wakeAt1
+        let wakeSystem1 = systemTime + wakeAt1 - sleepOffset1
+        clock.addTimeMarkers(wakeClock1, wakeSystem1)
+        
+        let sleepOffset2: TimeInterval = 2 * 60
+        let wakeAt2: TimeInterval = 3 * 60
+        let wakeClock2 = wakeClock1 + wakeAt2
+        let wakeSystem2 = wakeSystem1 + wakeAt2 - sleepOffset2
+        clock.addTimeMarkers(wakeClock2, wakeSystem2)
+        
+        let offsetAfter: TimeInterval = 10 * 60
+        let testTimeExpected = wakeClock2 + offsetAfter
+        let testTime = wakeSystem2 + offsetAfter
+        let testTimeActual = clock.relativeUptime(to: testTime)
+        XCTAssertEqual(testTimeExpected, testTimeActual, accuracy:0.0001)
+        
+        let zeroTimeActual = clock.zeroRelativeTime(to: testTime)
+        let zeroTimeEspected = testTimeActual - clockTime
+        XCTAssertEqual(zeroTimeEspected, zeroTimeActual, accuracy:0.0001)
     }
 }


### PR DESCRIPTION
This was a request by the research team to change the meaning of “timestamp” from system time to `0` at the start of the recording. This is an effort to achieve parity with the Android implementation where the `timestamp` is zeroed to the beginning of the recording.

- note: This does not address the issue where the clock used to set the step duration does not fire b/c the app was sent to the background due to answering a phone call while performing the walk and balance.