### PR TITLE
Fix equality for RSDAnswerResultType

### DIFF
--- a/Research/Research/RSDAnswerResultType.swift
+++ b/Research/Research/RSDAnswerResultType.swift
@@ -42,9 +42,26 @@ import Foundation
 /// - seealso: `RSDAnswerResult` and `RSDFormDataType`
 ///
 public struct RSDAnswerResultType : Codable, Hashable, Equatable {
-    
     private enum CodingKeys: String, CodingKey, CaseIterable {
         case baseType, sequenceType, formDataType, dateFormat, dateLocaleIdentifier, unit, sequenceSeparator
+    }
+    
+    /// Override equality to *not* include the original formDataType.
+    public static func == (lhs: RSDAnswerResultType, rhs: RSDAnswerResultType) -> Bool {
+        return lhs.baseType == rhs.baseType &&
+            lhs.sequenceType == rhs.sequenceType &&
+            lhs.dateFormat == rhs.dateFormat &&
+            lhs.unit == rhs.unit &&
+            lhs.sequenceSeparator == rhs.sequenceSeparator
+    }
+    
+    /// Override the hash into to *not* include the original formDataType.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(baseType)
+        if let hashV = self.sequenceType { hasher.combine(hashV) }
+        if let hashV = self.dateFormat { hasher.combine(hashV) }
+        if let hashV = self.unit { hasher.combine(hashV) }
+        if let hashV = self.sequenceSeparator { hasher.combine(hashV) }
     }
     
     /// The base type of the answer result. This is used to indicate what the type is of the

--- a/Research/ResearchTests/ModelObject Tests/ResultTests.swift
+++ b/Research/ResearchTests/ModelObject Tests/ResultTests.swift
@@ -85,5 +85,31 @@ class ResultTests: XCTestCase {
         let removedD = collection.removeInputResult(with: "d")
         XCTAssertNil(removedD)
     }
+    
+    func testAnswerTypeEquality_Boolean() {
+        let a = RSDAnswerResultType(baseType: .boolean, sequenceType: nil, formDataType: .base(.boolean), dateFormat: nil, unit: nil, sequenceSeparator: nil)
+        let b = RSDAnswerResultType.boolean
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
 
+    func testAnswerTypeEquality_StringCollection() {
+        let a = RSDAnswerResultType(baseType: .string, sequenceType: .array, formDataType: .collection(.multipleChoice, .string), dateFormat: nil, unit: nil, sequenceSeparator: "-")
+        let b = RSDAnswerResultType(baseType: .string, sequenceType: .array, formDataType: nil, dateFormat: nil, unit: nil, sequenceSeparator: "-")
+        let c = RSDAnswerResultType(baseType: .string, sequenceType: .array, formDataType: nil, dateFormat: nil, unit: nil, sequenceSeparator: nil)
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+        XCTAssertNotEqual(a, c)
+        XCTAssertNotEqual(a.hashValue, c.hashValue)
+    }
+    
+    func testAnswerTypeEquality_Date() {
+        let a = RSDAnswerResultType(baseType: .date, sequenceType: nil, formDataType: .base(.date), dateFormat: "YYYY-mm", unit: nil, sequenceSeparator: nil)
+        let b = RSDAnswerResultType(baseType: .date, sequenceType: nil, formDataType: nil, dateFormat: "YYYY-mm", unit: nil, sequenceSeparator: nil)
+        let c = RSDAnswerResultType.date
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+        XCTAssertNotEqual(a, c)
+        XCTAssertNotEqual(a.hashValue, c.hashValue)
+    }
 }


### PR DESCRIPTION
I'm not sure when this was changed, but the data type should be optional.