### PR TITLE
Fix permissions

### DIFF
--- a/RSDCatalog/RSDCatalog.xcodeproj/project.pbxproj
+++ b/RSDCatalog/RSDCatalog.xcodeproj/project.pbxproj
@@ -79,7 +79,6 @@
 
 /* Begin PBXFileReference section */
 		F801218122755548003A1A5C /* ResearchRecorders.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchRecorders.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F830840B21F2686C0055F9B8 /* MotorControl.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MotorControl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F836460A2265281400CCA0EF /* TaskPresentationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskPresentationViewController.swift; sourceTree = "<group>"; };
 		F836460C22652E6000CCA0EF /* TaskArchivesTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskArchivesTableViewController.swift; sourceTree = "<group>"; };
 		F8373C9220964F60004DD4E1 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -89,7 +88,6 @@
 		F84DDB6C20955628009CC1B8 /* Photos.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Photos.framework; path = System/Library/Frameworks/Photos.framework; sourceTree = SDKROOT; };
 		F871AA5022610D2F00C0F657 /* ColorPalettes.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ColorPalettes.json; sourceTree = "<group>"; };
 		F871AA5222610E8900C0F657 /* PaletteSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteSelectionViewController.swift; sourceTree = "<group>"; };
-		F8A503702225FE40005F1C0C /* CardiorespiratoryFitness.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CardiorespiratoryFitness.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8D42A4F2095518400C6A4BC /* RSDCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RSDCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8D42A522095518400C6A4BC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F8D42A592095518400C6A4BC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -244,8 +242,6 @@
 				F8D42AB52095550C00C6A4BC /* Research.framework */,
 				F8D42AB72095550C00C6A4BC /* ResearchUI.framework */,
 				F801218122755548003A1A5C /* ResearchRecorders.framework */,
-				F8A503702225FE40005F1C0C /* CardiorespiratoryFitness.framework */,
-				F830840B21F2686C0055F9B8 /* MotorControl.framework */,
 				F84DDB6C20955628009CC1B8 /* Photos.framework */,
 				F84DDB6B20955628009CC1B8 /* AVFoundation.framework */,
 				F84DDB6920955628009CC1B8 /* CoreLocation.framework */,

--- a/RSDTest/RSDTest.xcodeproj/project.pbxproj
+++ b/RSDTest/RSDTest.xcodeproj/project.pbxproj
@@ -9,10 +9,10 @@
 /* Begin PBXBuildFile section */
 		F8373C8920964EC7004DD4E1 /* RSDTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8373C8820964EC7004DD4E1 /* RSDTestTests.swift */; };
 		F8B1777E202CD31700B62416 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = F8B1777D202CD31700B62416 /* README.md */; };
-		F8B17823202D4E8400B62416 /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8B17822202D4E8400B62416 /* ResearchUI.framework */; };
-		F8B17824202D4E8400B62416 /* ResearchUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8B17822202D4E8400B62416 /* ResearchUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8B17827202D4E8C00B62416 /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8B17826202D4E8C00B62416 /* Research.framework */; };
-		F8B17828202D4E8C00B62416 /* Research.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8B17826202D4E8C00B62416 /* Research.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8D86F132280B27600897CDF /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8B17826202D4E8C00B62416 /* Research.framework */; };
+		F8D86F142280B27600897CDF /* Research.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8B17826202D4E8C00B62416 /* Research.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8D86F152280B27600897CDF /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8B17822202D4E8400B62416 /* ResearchUI.framework */; };
+		F8D86F162280B27600897CDF /* ResearchUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8B17822202D4E8400B62416 /* ResearchUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FF2415611F7AC31800D0BA5C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2415601F7AC31800D0BA5C /* AppDelegate.swift */; };
 		FF2415631F7AC31800D0BA5C /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2415621F7AC31800D0BA5C /* ViewController.swift */; };
 		FF2415661F7AC31800D0BA5C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF2415641F7AC31800D0BA5C /* Main.storyboard */; };
@@ -33,14 +33,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		F8B17825202D4E8400B62416 /* Embed Frameworks */ = {
+		F8D86F172280B27600897CDF /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F8B17828202D4E8C00B62416 /* Research.framework in Embed Frameworks */,
-				F8B17824202D4E8400B62416 /* ResearchUI.framework in Embed Frameworks */,
+				F8D86F142280B27600897CDF /* Research.framework in Embed Frameworks */,
+				F8D86F162280B27600897CDF /* ResearchUI.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -78,8 +78,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8B17827202D4E8C00B62416 /* Research.framework in Frameworks */,
-				F8B17823202D4E8400B62416 /* ResearchUI.framework in Frameworks */,
+				F8D86F132280B27600897CDF /* Research.framework in Frameworks */,
+				F8D86F152280B27600897CDF /* ResearchUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -98,6 +98,8 @@
 		F8B177E9202D330D00B62416 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F8B17826202D4E8C00B62416 /* Research.framework */,
+				F8B17822202D4E8400B62416 /* ResearchUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -109,8 +111,6 @@
 				FF24155F1F7AC31800D0BA5C /* RSDTest */,
 				F8373C8720964EC7004DD4E1 /* RSDTestTests */,
 				FF24155E1F7AC31800D0BA5C /* Products */,
-				F8B17826202D4E8C00B62416 /* Research.framework */,
-				F8B17822202D4E8400B62416 /* ResearchUI.framework */,
 				F8B177E9202D330D00B62416 /* Frameworks */,
 			);
 			sourceTree = "<group>";
@@ -184,7 +184,7 @@
 				FF2415591F7AC31800D0BA5C /* Sources */,
 				FF24155A1F7AC31800D0BA5C /* Frameworks */,
 				FF24155B1F7AC31800D0BA5C /* Resources */,
-				F8B17825202D4E8400B62416 /* Embed Frameworks */,
+				F8D86F172280B27600897CDF /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -207,13 +207,13 @@
 				TargetAttributes = {
 					F8373C8520964EC7004DD4E1 = {
 						CreatedOnToolsVersion = 9.3;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						TestTargetID = FF24155C1F7AC31800D0BA5C;
 					};
 					FF24155C1F7AC31800D0BA5C = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -327,7 +327,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.sagebase.RSDTestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RSDTest.app/RSDTest";
 			};
@@ -347,7 +347,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.sagebase.RSDTestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RSDTest.app/RSDTest";
 			};
@@ -483,7 +483,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "877c46a3-e438-4856-ab71-0df11d8f51c4";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development: org.sagebase.RSDTest";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -506,7 +506,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "84a674c1-10a5-4b79-b2e8-05507424ffec";
 				PROVISIONING_PROFILE_SPECIFIER = "match Distribution: org.sagebase.RSDTest";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Research.xcworkspace/contents.xcworkspacedata
+++ b/Research.xcworkspace/contents.xcworkspacedata
@@ -10,4 +10,7 @@
    <FileRef
       location = "group:RK1Translator/RK1Translator.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:RK1Translator/../RSDTest/RSDTest.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/Research/Research.xcodeproj/project.pbxproj
+++ b/Research/Research.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		F801217922751561003A1A5C /* RSDLocationAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E94FF020585ED100752B7B /* RSDLocationAuthorization.swift */; };
 		F801217A22751561003A1A5C /* RSDMotionAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E94FF42058602F00752B7B /* RSDMotionAuthorization.swift */; };
 		F801217B22751561003A1A5C /* RSDPhotoLibraryAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E94FFA20586D7500752B7B /* RSDPhotoLibraryAuthorization.swift */; };
-		F801217C2275157D003A1A5C /* ResearchRecorders.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F814DCE722750435004579EF /* ResearchRecorders.framework */; };
+		F801217C2275157D003A1A5C /* ResearchRecorders.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F814DCE722750435004579EF /* ResearchRecorders.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		F801218022755516003A1A5C /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF8B53141FCE678E006B6937 /* Research.framework */; };
 		F802F3E3204DF2B80027CB00 /* RSDUIStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802F3E2204DF2B80027CB00 /* RSDUIStep.swift */; };
 		F802F3E4204DF2B80027CB00 /* RSDUIStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802F3E2204DF2B80027CB00 /* RSDUIStep.swift */; };

--- a/Research/Research/RSDDocumentable.swift
+++ b/Research/Research/RSDDocumentable.swift
@@ -56,6 +56,7 @@ public struct RSDDocumentCreator {
         RSDFormUIHint.self,
         RSDIdentifier.self,
         RSDKeyboardType.self,
+        RSDMotionRecorderType.self,
         RSDResultType.self,
         RSDStandardPermissionType.self,
         RSDStepType.self,
@@ -64,13 +65,6 @@ public struct RSDDocumentCreator {
         RSDTextAutocorrectionType.self,
         RSDTextSpellCheckingType.self,
         ]
-    
-    #if os(iOS)
-        let iOSEnums: [RSDDocumentableStringEnum.Type] = [
-            RSDMotionRecorderType.self,
-            ]
-        allEnums.append(contentsOf: iOSEnums)
-    #endif
         
         return allEnums
     }()

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -8,7 +8,8 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then     # on pull requests
 elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" == "master" ]]; then  # non-tag commits to master branch
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test scheme:"RSDCatalog"
     bundle exec fastlane keychains
-    bundle exec fastlane ci_archive scheme:"RSDCatalog" export_method:"app-store" 
+    bundle exec fastlane ci_archive scheme:"RSDCatalog" export_method:"app-store"
+    bundle exec fastlane ci_archive scheme:"RSDTest" export_method:"app-store"
     bundle exec fastlane build scheme:"Research-watchOS"
     bundle exec fastlane build scheme:"Research-tvOS"
     bundle exec fastlane build scheme:"Research-macOS"
@@ -17,6 +18,6 @@ elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" =~ ^stable-.* ]]; then # non-tag co
     bundle exec fastlane bump_all
     bundle exec fastlane keychains
     bundle exec fastlane beta scheme:"RSDCatalog" export_method:"app-store" project:"RSDCatalog/RSDCatalog.xcodeproj"
-    # bundle exec fastlane beta scheme:"RSDTest" export_method:"app-store" project:"RSDTest/RSDTest.xcodeproj"
+    bundle exec fastlane beta scheme:"RSDTest" export_method:"app-store" project:"RSDTest/RSDTest.xcodeproj"
 fi
 exit $?


### PR DESCRIPTION
Over the weekend Dan attempted to submit CRFSampleApp without the privacy permissions for location. With Xcode 10 and targeting iOS 11 and above, this was allowed.  Looks like that has changed with Xcode 10.2 and adding RSDTest back in to the workspace is the first step in looking to resolve how to optionally build in frameworks.