### PR TITLE
Do not turn off the “silence” audio until finished

### DIFF
--- a/Research/ResearchMotion/RSDMotionAudioSessionController.swift
+++ b/Research/ResearchMotion/RSDMotionAudioSessionController.swift
@@ -109,14 +109,18 @@ public final class RSDMotionAudioSessionController : NSObject, RSDAudioSessionCo
     public func stopAudioSession() {
         
         // Stop the audio player
-        self.audioPlayer?.stop()
+        if self.audioPlayer?.isPlaying ?? false {
+            self.audioPlayer?.stop()
+        }
         
         // Release the session
-        do {
-            audioSession = nil
-            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-        } catch let err {
-            debugPrint("Failed to stop AV session. \(err)")
+        if audioSession != nil {
+            do {
+                audioSession = nil
+                try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            } catch let err {
+                debugPrint("Failed to stop AV session. \(err)")
+            }
         }
     }
 }

--- a/Research/ResearchUI/iOS/RSDTaskViewController.swift
+++ b/Research/ResearchUI/iOS/RSDTaskViewController.swift
@@ -457,7 +457,6 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
     /// will be called when either (a) the task is ready to dismiss or (b) when the task is displaying
     /// the *last* completion step.
     open func handleTaskResultReady(with taskViewModel: RSDTaskViewModel) {
-        _stopAudioSession()
         delegate?.taskController(self, readyToSave: taskViewModel)
     }
     


### PR DESCRIPTION
Discovered in testing the Walk and Balance that the “Great job, you are now finished with the walk and balance” that is on the completion step gets swallowed. The RSDCatalog task doesn’t have a string that long on the last step.