### PR TITLE
Update font rules to match Sage Design System - Fonts V2

### DIFF
--- a/RSDCatalog/RSDCatalog/JSON Files/Recorder_Motion.json
+++ b/RSDCatalog/RSDCatalog/JSON Files/Recorder_Motion.json
@@ -47,7 +47,7 @@
                                                "identifier"         : "motion",
                                                "type"               : "active",
                                                "duration"           : 30,
-                                               "text"               : "Shake your phone",
+                                               "title"              : "Shake your phone",
                                                "image": {
                                                    "type": "fetchable",
                                                    "imageName": "HoldPhone",
@@ -55,6 +55,18 @@
                                                },
                                                "commands"           : ["startTimerAutomatically", "shouldDisableIdleTimer", "vibrate",
                                                                        "playSound"],
+                                               "actions":{
+                                                   "skip":{
+                                                       "type":"navigation",
+                                                       "skipToIdentifier":"countdown",
+                                                       "buttonTitle": "Restart test"
+                                                   },
+                                                   "reviewInstructions":{
+                                                       "type":"navigation",
+                                                       "skipToIdentifier": "instruction",
+                                                       "buttonTitle": "Review instructions"
+                                                   }
+                                               },
                                                "spokenInstructions" : { "start": "Start shaking your phone",
                                                                         "halfway": "Halfway there. Keep shaking!",
                                                                         "countdown": "10",

--- a/RSDCatalog/RSDCatalog/PaletteSelectionViewController.swift
+++ b/RSDCatalog/RSDCatalog/PaletteSelectionViewController.swift
@@ -81,15 +81,15 @@ class PaletteSelectionViewController: UITableViewController {
         
         cell.primary.backgroundColor = palette.primary.normal.color
         cell.primaryLabel.text = "\(palette.primary.swatch.name) \(palette.primary.index)"
-        cell.primaryLabel.textColor = designSystem.colorRules.textColor(on: palette.primary.normal, for: .heading4)
+        cell.primaryLabel.textColor = designSystem.colorRules.textColor(on: palette.primary.normal, for: .smallHeader)
         
         cell.secondary.backgroundColor = palette.secondary.normal.color
         cell.secondaryLabel.text = "\(palette.secondary.swatch.name) \(palette.secondary.index)"
-        cell.secondaryLabel.textColor = designSystem.colorRules.textColor(on: palette.secondary.normal, for: .heading4)
+        cell.secondaryLabel.textColor = designSystem.colorRules.textColor(on: palette.secondary.normal, for: .smallHeader)
         
         cell.accent.backgroundColor = palette.accent.normal.color
         cell.accentLabel.text = "\(palette.accent.swatch.name) \(palette.accent.index)"
-        cell.accentLabel.textColor = designSystem.colorRules.textColor(on: palette.accent.normal, for: .heading4)
+        cell.accentLabel.textColor = designSystem.colorRules.textColor(on: palette.accent.normal, for: .smallHeader)
         
         return cell
     }
@@ -117,7 +117,7 @@ class PaletteSelectionViewController: UITableViewController {
     func updateHeader(_ header: TableSectionHeader) {
         let palette = RSDStudyConfiguration.shared.colorPalette
         header.contentView.backgroundColor = palette.primary.normal.color
-        header.titleLabel.textColor = designSystem.colorRules.textColor(on: palette.primary.normal, for: .heading4)
+        header.titleLabel.textColor = designSystem.colorRules.textColor(on: palette.primary.normal, for: .smallHeader)
         header.titleLabel.text = "\(palette.primary.swatch.name) \(palette.primary.index)"
         header.secondaryDot.backgroundColor = palette.secondary.normal.color
         header.accentDot.backgroundColor = palette.accent.normal.color

--- a/Research/Research-UnitTest/Info.plist
+++ b/Research/Research-UnitTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/ColorMatrix.json
+++ b/Research/Research/ColorMatrix.json
@@ -703,4 +703,328 @@
             "usesLightStyle": true
         }]
     }]
+},
+{
+    "version": 2,
+    "grayScale": {
+        "white": {
+            "color": "white",
+            "usesLightStyle": false
+        },
+        "veryLightGray": {
+            "color": "#EAEBEE",
+            "usesLightStyle": false
+        },
+        "lightGray": {
+            "color": "#C3C7D1",
+            "usesLightStyle": false
+        },
+        "gray": {
+            "color": "#9DA3B3",
+            "usesLightStyle": false
+        },
+        "darkGray": {
+            "color": "#777F95",
+            "usesLightStyle": true
+        },
+        "veryDarkGray": {
+            "color": "#575E71",
+            "usesLightStyle": true
+        },
+        "black": {
+            "color": "#2A2A2A",
+            "usesLightStyle": true
+        }
+    },
+    "swatches": [
+    {
+        "name": "text",
+        "colorTiles": [{
+            "color": "white",
+            "usesLightStyle": false
+        }, {
+            "color": "#EAEBEE",
+            "usesLightStyle": false
+        }, {
+            "color": "#9DA3B3",
+            "usesLightStyle": false
+        }, {
+            "color": "#777F95",
+            "usesLightStyle": false
+        }, {
+            "color": "#2A2A2A",
+            "usesLightStyle": true
+        }]
+    },
+    {
+        "name": "royal",
+        "colorTiles": [{
+            "color": "#A294CA",
+            "usesLightStyle": false
+        }, {
+            "color": "#7B67B3",
+            "usesLightStyle": true
+        }, {
+            "color": "#5A478F",
+            "usesLightStyle": true
+        }, {
+            "color": "#3D3062",
+            "usesLightStyle": true
+        }, {
+            "color": "#211A34",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "butterscotch",
+        "colorTiles": [{
+            "color": "#FCE5BD",
+            "usesLightStyle": false
+        }, {
+            "color": "#F8CC7D",
+            "usesLightStyle": false
+        }, {
+            "color": "#F5B33C",
+            "usesLightStyle": false
+        }, {
+            "color": "#E2950C",
+            "usesLightStyle": false
+        }, {
+            "color": "#A16A08",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "stone",
+        "colorTiles": [{
+            "color": "#FCFCFC",
+            "usesLightStyle": false
+        }, {
+            "color": "#DBD9D9",
+            "usesLightStyle": false
+        }, {
+            "color": "#BAB6B6",
+            "usesLightStyle": false
+        }, {
+            "color": "#999393",
+            "usesLightStyle": false
+        }, {
+            "color": "#777171",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "powder",
+        "colorTiles": [{
+            "color": "#DFF2F2",
+            "usesLightStyle": false
+        }, {
+            "color": "#AFDDDF",
+            "usesLightStyle": false
+        }, {
+            "color": "#7EC8CC",
+            "usesLightStyle": false
+        }, {
+            "color": "#4DB3B9",
+            "usesLightStyle": false
+        }, {
+            "color": "#37878B",
+            "usesLightStyle": false
+        }]
+    }, {
+        "name": "turquoise",
+        "colorTiles": [{
+            "color": "#75E2D8",
+            "usesLightStyle": false
+        }, {
+            "color": "#3DD6C8",
+            "usesLightStyle": false
+        }, {
+            "color": "#24AB9F",
+            "usesLightStyle": false
+        }, {
+            "color": "#18736B",
+            "usesLightStyle": true
+        }, {
+            "color": "#0C3B37",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "coral",
+        "colorTiles": [{
+            "color": "#FDEDEA",
+            "usesLightStyle": false
+        }, {
+            "color": "#F9B5AB",
+            "usesLightStyle": false
+        }, {
+            "color": "#F47E6C",
+            "usesLightStyle": false
+        }, {
+            "color": "#EF472D",
+            "usesLightStyle": false
+        }, {
+            "color": "#C9280F",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "apricot",
+        "colorTiles": [{
+            "color": "#F7CDAD",
+            "usesLightStyle": false
+        }, {
+            "color": "#F1A86F",
+            "usesLightStyle": false
+        }, {
+            "color": "#EB8231",
+            "usesLightStyle": false
+        }, {
+            "color": "#C56113",
+            "usesLightStyle": false
+        }, {
+            "color": "#87420D",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "successGreen",
+        "colorTiles": [{
+            "color": "#CEF1E0",
+            "usesLightStyle": false
+        }, {
+            "color": "#98E3BF",
+            "usesLightStyle": false
+        }, {
+            "color": "#63D49E",
+            "usesLightStyle": false
+        }, {
+            "color": "#35BF7D",
+            "usesLightStyle": false
+        }, {
+            "color": "#26895A",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "blueberry",
+        "colorTiles": [{
+            "color": "#BBD3E2",
+            "usesLightStyle": false
+        }, {
+            "color": "#8BB4CE",
+            "usesLightStyle": false
+        }, {
+            "color": "#5B95BA",
+            "usesLightStyle": false
+        }, {
+            "color": "#3E7293",
+            "usesLightStyle": true
+        }, {
+            "color": "#2A4D63",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "apple",
+        "colorTiles": [{
+            "color": "#E9AAAD",
+            "usesLightStyle": false
+        }, {
+            "color": "#DA7579",
+            "usesLightStyle": false
+        }, {
+            "color": "#CC3F45",
+            "usesLightStyle": true
+        }, {
+            "color": "#9D2A2F",
+            "usesLightStyle": true
+        }, {
+            "color": "#681C1F",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "errorRed",
+        "colorTiles": [{
+            "color": "#FBDBDE",
+            "usesLightStyle": false
+        }, {
+            "color": "#F59DA7",
+            "usesLightStyle": false
+        }, {
+            "color": "#EE6070",
+            "usesLightStyle": false
+        }, {
+            "color": "#E72339",
+            "usesLightStyle": true
+        }, {
+            "color": "#B31325",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "rose",
+        "colorTiles": [{
+            "color": "#F9DAE8",
+            "usesLightStyle": false
+        }, {
+            "color": "#EFA0C5",
+            "usesLightStyle": false
+        }, {
+            "color": "#E566A1",
+            "usesLightStyle": false
+        }, {
+            "color": "#DB2C7D",
+            "usesLightStyle": false
+        }, {
+            "color": "#A71C5D",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "lavender",
+        "colorTiles": [{
+            "color": "#E0E7F7",
+            "usesLightStyle": false
+        }, {
+            "color": "#ABBCE8",
+            "usesLightStyle": false
+        }, {
+            "color": "#7692D9",
+            "usesLightStyle": false
+        }, {
+            "color": "#4168CA",
+            "usesLightStyle": true
+        }, {
+            "color": "#2B4B9C",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "slate",
+        "colorTiles": [{
+            "color": "#92A3C1",
+            "usesLightStyle": false
+        }, {
+            "color": "#677FA8",
+            "usesLightStyle": false
+        }, {
+            "color": "#4A5E81",
+            "usesLightStyle": true
+        }, {
+            "color": "#313F56",
+            "usesLightStyle": true
+        }, {
+            "color": "#181F2B",
+            "usesLightStyle": true
+        }]
+    }, {
+        "name": "fern",
+        "colorTiles": [{
+            "color": "#C7E3D0",
+            "usesLightStyle": false
+        }, {
+            "color": "#9ACCAB",
+            "usesLightStyle": false
+        }, {
+            "color": "#6DB585",
+            "usesLightStyle": false
+        }, {
+            "color": "#4B9363",
+            "usesLightStyle": false
+        }, {
+            "color": "#346645",
+            "usesLightStyle": true
+        }]
+    }]
 }]

--- a/Research/Research/Info-iOS.plist
+++ b/Research/Research/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-macOS.plist
+++ b/Research/Research/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Research/Research/Info-tvOS.plist
+++ b/Research/Research/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-watchOS.plist
+++ b/Research/Research/Info-watchOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/RSDColorMatrix.swift
+++ b/Research/Research/RSDColorMatrix.swift
@@ -265,8 +265,8 @@ public enum RSDReservedColorName : RawRepresentable, Equatable, Hashable, Codabl
         case lavender
         case slate
         case fern
-        case cloud
         case stone
+        case cloud
     }
     
     case special(Special)
@@ -276,6 +276,7 @@ public enum RSDReservedColorName : RawRepresentable, Equatable, Hashable, Codabl
         case text
     }
     
+    /// Minimum version in which a reserved color name was introduced.
     public var minVersion: Int {
         switch self {
         case .special(.text):
@@ -288,7 +289,12 @@ public enum RSDReservedColorName : RawRepresentable, Equatable, Hashable, Codabl
     /// Maximum version in which a given reserved color name is expected to be included. If `nil` this color
     /// name should still be included in the color matrix in the most recent library.
     public var version: Int? {
-        return nil
+        switch self {
+        case .palette(.cloud):
+            return 1
+        default:
+            return nil
+        }
     }
     
     public init?(rawValue: String) {

--- a/Research/Research/RSDColorRules.swift
+++ b/Research/Research/RSDColorRules.swift
@@ -193,20 +193,44 @@ open class RSDColorRules  {
     ///     else `text.dark`
     /// ```
     ///
+    /// - Default: (version 2)
+    /// ```
+    ///     See the Sage Design System table.
+    ///     https://www.figma.com/file/nvoSigSxbFuWzGXgUZAf8M/DigitalHealth_DesignSystem-Master?node-id=3837%3A16223
+    /// ```
+    ///
     /// - parameters:
     ///     - background: The background of the text UI element.
     ///     - textType: The type size of the UI element.
     /// - returns: The text color to use.
     open func textColor(on background: RSDColorTile, for textType: RSDDesignSystem.TextType) -> RSDColor {
-        if background.usesLightStyle {
-            return self.palette.text.light.color
+        if version >= 2 {
+            if background.usesLightStyle {
+                return self.palette.text.light.color
+            }
+            else {
+                switch textType {
+                case .hint, .microDetail:
+                    return self.palette.text.normal.color
+                case .small, .bodyDetail:
+                    return self.palette.text.dark.color
+                default:
+                    return self.palette.text.veryDark.color
+                }
+            }
         }
         else {
-            switch textType {
-            case .small, .bodyDetail:
-                return self.palette.text.normal.color
-            default:
-                return self.palette.text.dark.color
+            // Version 0 and 1 only have 3 colors defined, so need to match within that.
+            if background.usesLightStyle {
+                return self.palette.text.light.color
+            }
+            else {
+                switch textType {
+                case .small, .bodyDetail, .hint, .microDetail:
+                    return self.palette.text.normal.color
+                default:
+                    return self.palette.text.dark.color
+                }
             }
         }
     }
@@ -401,7 +425,7 @@ open class RSDColorRules  {
     /// - returns: The color to use for the text of a rounded button.
     open func roundedButtonText(on background: RSDColorTile, with buttonType: RSDDesignSystem.ButtonType, forState state: RSDControlState) -> RSDColor {
         let tile = self.roundedButton(on: background, buttonType: buttonType)
-        let color = textColor(on: tile.normal, for: .heading4)
+        let color = textColor(on: tile.normal, for: .body)
         if state == .disabled && !tile.normal.usesLightStyle {
             return color.withAlphaComponent(0.35)
         }

--- a/Research/Research/RSDColorRules.swift
+++ b/Research/Research/RSDColorRules.swift
@@ -204,9 +204,9 @@ open class RSDColorRules  {
     ///     - textType: The type size of the UI element.
     /// - returns: The text color to use.
     open func textColor(on background: RSDColorTile, for textType: RSDDesignSystem.TextType) -> RSDColor {
-        if version >= 2 {
+        if self.palette.text.colorTiles.count == 5 {
             if background.usesLightStyle {
-                return self.palette.text.light.color
+                return self.palette.text.veryLight.color
             }
             else {
                 switch textType {
@@ -219,18 +219,26 @@ open class RSDColorRules  {
                 }
             }
         }
-        else {
+        else if self.palette.text.colorTiles.count > 0 {
             // Version 0 and 1 only have 3 colors defined, so need to match within that.
             if background.usesLightStyle {
-                return self.palette.text.light.color
+                return self.palette.text.colorTiles.first!.color
             }
             else {
                 switch textType {
                 case .small, .bodyDetail, .hint, .microDetail:
                     return self.palette.text.normal.color
                 default:
-                    return self.palette.text.dark.color
+                    return self.palette.text.colorTiles.last!.color
                 }
+            }
+        }
+        else {
+            if background.usesLightStyle {
+                return self.palette.grayScale.white.color
+            }
+            else {
+                return self.palette.grayScale.black.color
             }
         }
     }

--- a/Research/Research/RSDDesignSystem.swift
+++ b/Research/Research/RSDDesignSystem.swift
@@ -76,20 +76,50 @@ open class RSDDesignSystem {
     /// The button type for the button. This refers to whether or not the button is used to represent a
     /// primary or secondary action.
     public enum ButtonType: String, Codable, CaseIterable {
-        case primary, secondary
+        case primary, secondary, toggle, bodyLink, headerLink
     }
     
     /// The supported text types for the text fields and labels.
-    public enum TextType : String, Codable, CaseIterable {
-        case heading1
-        case heading2       // step title
-        case heading3
-        case heading4
-        case fieldHeader
-        case body           // step text
-        case bodyDetail     // step detail
-        case small          // step footnote
-        case microHeader
-        case counter
+    public struct TextType : RawRepresentable, Codable, ExpressibleByStringLiteral, Hashable {
+        public let rawValue: String
+        
+        public init?(rawValue: String) {
+            self.rawValue = rawValue
+        }
+        
+        public init(stringLiteral value: String) {
+            self.rawValue = value
+        }
+        
+        // Version 2
+        public static let largeNumber: TextType = "largeNumber"
+        public static let smallNumber: TextType = "smallNumber"
+        public static let xLargeHeader: TextType = "xLargeHeader"
+        public static let largeHeader: TextType = "largeHeader"
+        public static let largeBody: TextType = "largeBody"
+        public static let xSmallNumber: TextType = "xSmallNumber"
+        public static let mediumHeader: TextType = "mediumHeader"
+        public static let body: TextType = "body"
+        public static let bodyDetail: TextType = "bodyDetail"
+        public static let italicDetail: TextType = "italicDetail"
+        public static let smallHeader: TextType = "smallHeader"
+        public static let small: TextType = "small"
+        public static let hint: TextType = "hint"    // placeholder
+        public static let microHeader: TextType = "microHeader"
+        public static let microDetail: TextType = "microDetail"
+        
+        // Version 1
+        @available(*,deprecated)
+        public static let heading1: TextType = "heading1"
+        @available(*,deprecated)
+        public static let heading2: TextType = "heading2"
+        @available(*,deprecated)
+        public static let heading3: TextType = "heading3"
+        @available(*,deprecated)
+        public static let heading4: TextType = "heading4"
+        @available(*,deprecated)
+        public static let fieldHeader: TextType = "fieldHeader"
+        @available(*,deprecated)
+        public static let counter: TextType = "counter"
     }
 }

--- a/Research/Research/RSDFontRules.swift
+++ b/Research/Research/RSDFontRules.swift
@@ -164,7 +164,11 @@ open class RSDFontRules  {
         case .bodyDetail:
             return RSDFont.systemFont(ofSize: 16)
         case .italicDetail:
+            #if os(macOS)
+            return RSDFont.systemFont(ofSize: 16)
+            #else
             return RSDFont.italicSystemFont(ofSize: 16)
+            #endif
         case .small, .hint:
             return RSDFont.systemFont(ofSize: 16)
         case .microDetail:

--- a/Research/Research/RSDFontRules.swift
+++ b/Research/Research/RSDFontRules.swift
@@ -76,12 +76,101 @@ open class RSDFontRules  {
     }
     #endif
     
+    /// Returns the font to use for the given button type and state.
+    ///
+    /// - parameters:
+    ///     - buttonType: The button type.
+    ///     - state: The button state.
+    /// - returns: The font to use for this text.
+    open func buttonFont(for buttonType: RSDDesignSystem.ButtonType, state: RSDControlState) -> RSDFont {
+        switch buttonType {
+            
+        case .primary, .secondary:
+            return RSDFont.systemFont(ofSize: 20, weight: .bold)
+            
+        case .bodyLink:
+            return baseFont(for: .body)
+            
+        case .headerLink:
+            return baseFont(for: .smallHeader)
+            
+        case .toggle:
+            switch state {
+            case .selected:
+                return RSDFont.systemFont(ofSize: 16, weight: .bold)
+            default:
+                return RSDFont.systemFont(ofSize: 16, weight: .regular)
+            }
+        }
+    }
+    
     /// Returns the font to use for a given text type.
     ///
     /// - parameter textType: The text type for the font.
     /// - returns: The font to use for this text.
     open func font(for textType: RSDDesignSystem.TextType) -> RSDFont {
+        // TODO: syoung 07/03/2019 Implement dynamic text handling.
+        return baseFont(for: textType)
+    }
+    
+    /// Returns a font in the given size and weight in the font family specified for this design.
+    /// Typically, you will want to use `font(for textType: RSDDesignSystem.TextType)` instead for
+    /// copy and dynamic text. This method should only be used where the design calls for a
+    /// specific size to match the graphic design of the view.
+    ///
+    /// - parameters:
+    ///     - fontSize: The font size.
+    ///     - weight: The font weight.
+    /// - returns: The font to use for this size and weight.
+    open func font(ofSize fontSize: CGFloat, weight: RSDFont.Weight) -> RSDFont {
+        return RSDFont.systemFont(ofSize: fontSize, weight: weight)
+    }
+    
+    /// Returns the base font for a given text type. This is the font size defined in the Sage
+    /// Design System table. For dynamic fonts, this can be resized based upon user preferences by
+    /// using the `font(for textType: RSDDesignSystem.TextType)` instead.
+    ///
+    /// This is *only* to be used directly where the text needs to fix within a specific size, but
+    /// match the "style" of a given text type.
+    ///
+    /// - parameter textType: The text type for the font.
+    /// - returns: The *base* font to use for this text.
+    open func baseFont(for textType: RSDDesignSystem.TextType) -> RSDFont {
         switch textType {
+            
+        // Version 2
+        case .largeNumber:
+            return RSDFont.systemFont(ofSize: 72, weight: .light)
+        case .smallNumber:
+            return RSDFont.systemFont(ofSize: 48, weight: .light)
+        case .xSmallNumber:
+            return RSDFont.systemFont(ofSize: 20, weight: .light)
+
+        case .xLargeHeader:
+            return RSDFont.systemFont(ofSize: 30, weight: .bold)
+        case .largeHeader:
+            return RSDFont.systemFont(ofSize: 24, weight: .bold)
+        case .mediumHeader:
+            return RSDFont.systemFont(ofSize: 18, weight: .bold)
+        case .smallHeader:
+            return RSDFont.systemFont(ofSize: 16, weight: .bold)
+        case .microHeader:
+            return RSDFont.systemFont(ofSize: 14).rsd_smallCaps()
+        
+        case .largeBody:
+            return RSDFont.systemFont(ofSize: 24, weight: .light)
+        case .body:
+            return RSDFont.systemFont(ofSize: 18)
+        case .bodyDetail:
+            return RSDFont.systemFont(ofSize: 16)
+        case .italicDetail:
+            return RSDFont.italicSystemFont(ofSize: 16)
+        case .small, .hint:
+            return RSDFont.systemFont(ofSize: 16)
+        case .microDetail:
+            return RSDFont.systemFont(ofSize: 14)
+            
+        // Version 1
         case .heading1:
             return RSDFont.systemFont(ofSize: 30, weight: .bold)
         case .heading2:
@@ -92,14 +181,24 @@ open class RSDFontRules  {
             return RSDFont.systemFont(ofSize: 18, weight: .bold)
         case .fieldHeader:
             return RSDFont.systemFont(ofSize: 16, weight: .heavy)
-        case .body, .bodyDetail:
-            return RSDFont.systemFont(ofSize: 18)
-        case .small:
-            return RSDFont.systemFont(ofSize: 14)
-        case .microHeader:
-            return RSDFont.systemFont(ofSize: 12, weight: .semibold).rsd_smallCaps()
         case .counter:
             return RSDFont.systemFont(ofSize: 80, weight: .light)
+            
+        default:
+            assertionFailure("\(textType) is not defined. Returning `body` type.")
+            return RSDFont.systemFont(ofSize: 18)
+        }
+    }
+    
+    /// Returns whether or not the specified text type is dynamic.
+    /// - parameter textType: The text type for the font.
+    open func isDynamic(_ textType: RSDDesignSystem.TextType) -> Bool {
+        switch textType {
+        case .xLargeHeader, .largeHeader, .mediumHeader, .smallHeader,
+             .body, .bodyDetail, .italicDetail, .small, .hint, .microDetail:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/Research/Research/RSDFontRules.swift
+++ b/Research/Research/RSDFontRules.swift
@@ -86,7 +86,7 @@ open class RSDFontRules  {
         switch buttonType {
             
         case .primary, .secondary:
-            return RSDFont.systemFont(ofSize: 20, weight: .bold)
+            return font(ofSize: 20, weight: .bold)
             
         case .bodyLink:
             return baseFont(for: .body)
@@ -97,9 +97,9 @@ open class RSDFontRules  {
         case .toggle:
             switch state {
             case .selected:
-                return RSDFont.systemFont(ofSize: 16, weight: .bold)
+                return font(ofSize: 16, weight: .bold)
             default:
-                return RSDFont.systemFont(ofSize: 16, weight: .regular)
+                return font(ofSize: 16, weight: .regular)
             }
         }
     }
@@ -118,11 +118,14 @@ open class RSDFontRules  {
     /// copy and dynamic text. This method should only be used where the design calls for a
     /// specific size to match the graphic design of the view.
     ///
+    /// - note: All other methods on this class will call through to this method, so for custom
+    ///         fonts, you can override this method only if the only change is a custom font.
+    ///
     /// - parameters:
     ///     - fontSize: The font size.
     ///     - weight: The font weight.
     /// - returns: The font to use for this size and weight.
-    open func font(ofSize fontSize: CGFloat, weight: RSDFont.Weight) -> RSDFont {
+    open func font(ofSize fontSize: CGFloat, weight: RSDFont.Weight = .regular) -> RSDFont {
         return RSDFont.systemFont(ofSize: fontSize, weight: weight)
     }
     
@@ -140,57 +143,53 @@ open class RSDFontRules  {
             
         // Version 2
         case .largeNumber:
-            return RSDFont.systemFont(ofSize: 72, weight: .light)
+            return font(ofSize: 72, weight: .light)
         case .smallNumber:
-            return RSDFont.systemFont(ofSize: 48, weight: .light)
+            return font(ofSize: 48, weight: .light)
         case .xSmallNumber:
-            return RSDFont.systemFont(ofSize: 20, weight: .light)
+            return font(ofSize: 20, weight: .light)
 
         case .xLargeHeader:
-            return RSDFont.systemFont(ofSize: 30, weight: .bold)
+            return font(ofSize: 30, weight: .bold)
         case .largeHeader:
-            return RSDFont.systemFont(ofSize: 24, weight: .bold)
+            return font(ofSize: 24, weight: .bold)
         case .mediumHeader:
-            return RSDFont.systemFont(ofSize: 18, weight: .bold)
+            return font(ofSize: 18, weight: .bold)
         case .smallHeader:
-            return RSDFont.systemFont(ofSize: 16, weight: .bold)
+            return font(ofSize: 16, weight: .bold)
         case .microHeader:
-            return RSDFont.systemFont(ofSize: 14).rsd_smallCaps()
+            return font(ofSize: 14).rsd_smallCaps()
         
         case .largeBody:
-            return RSDFont.systemFont(ofSize: 24, weight: .light)
+            return font(ofSize: 24, weight: .light)
         case .body:
-            return RSDFont.systemFont(ofSize: 18)
+            return font(ofSize: 18)
         case .bodyDetail:
-            return RSDFont.systemFont(ofSize: 16)
+            return font(ofSize: 16)
         case .italicDetail:
-            #if os(macOS)
-            return RSDFont.systemFont(ofSize: 16)
-            #else
-            return RSDFont.italicSystemFont(ofSize: 16)
-            #endif
+            return font(ofSize: 16).rsd_italic()
         case .small, .hint:
-            return RSDFont.systemFont(ofSize: 16)
+            return font(ofSize: 16)
         case .microDetail:
-            return RSDFont.systemFont(ofSize: 14)
+            return font(ofSize: 14)
             
         // Version 1
         case .heading1:
-            return RSDFont.systemFont(ofSize: 30, weight: .bold)
+            return font(ofSize: 30, weight: .bold)
         case .heading2:
-            return RSDFont.systemFont(ofSize: 24, weight: .bold)
+            return font(ofSize: 24, weight: .bold)
         case .heading3:
-            return RSDFont.systemFont(ofSize: 20, weight: .heavy)
+            return font(ofSize: 20, weight: .heavy)
         case .heading4:
-            return RSDFont.systemFont(ofSize: 18, weight: .bold)
+            return font(ofSize: 18, weight: .bold)
         case .fieldHeader:
-            return RSDFont.systemFont(ofSize: 16, weight: .heavy)
+            return font(ofSize: 16, weight: .heavy)
         case .counter:
-            return RSDFont.systemFont(ofSize: 80, weight: .light)
+            return font(ofSize: 80, weight: .light)
             
         default:
             assertionFailure("\(textType) is not defined. Returning `body` type.")
-            return RSDFont.systemFont(ofSize: 18)
+            return font(ofSize: 18)
         }
     }
     
@@ -213,15 +212,32 @@ extension NSFont {
     func rsd_smallCaps() -> RSDFont {
         return self
     }
+    
+    func rsd_italic() -> RSDFont {
+        return self
+    }
 }
 #else
 extension UIFont {
+    
+    public func withTraits(traits: UIFontDescriptor.SymbolicTraits) -> UIFont {
+        guard let descriptor = fontDescriptor.withSymbolicTraits(traits)
+            else {
+                debugPrint("WARNING!! Failed to create font with \(traits)")
+                return self
+        }
+        return UIFont(descriptor: descriptor, size: 0)
+    }
     
     func rsd_smallCaps() -> RSDFont {
         let settings: [[UIFontDescriptor.FeatureKey : Int]] = [[.featureIdentifier: kLowerCaseType, .typeIdentifier: kLowerCaseSmallCapsSelector]]
         let attributes: [UIFontDescriptor.AttributeName : Any] = [.featureSettings: settings]
         let fontDescriptor = self.fontDescriptor.addingAttributes(attributes)
         return UIFont(descriptor: fontDescriptor, size: pointSize)
+    }
+    
+    func rsd_italic() -> RSDFont {
+        return self.withTraits(traits: .traitItalic)
     }
 }
 #endif

--- a/Research/ResearchLocation/Info.plist
+++ b/Research/ResearchLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 </dict>

--- a/Research/ResearchLocationTests/Info.plist
+++ b/Research/ResearchLocationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 </dict>

--- a/Research/ResearchMotion/Info.plist
+++ b/Research/ResearchMotion/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 </dict>

--- a/Research/ResearchMotionTests/Info.plist
+++ b/Research/ResearchMotionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 </dict>

--- a/Research/ResearchRecorders/Info-iOS.plist
+++ b/Research/ResearchRecorders/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 </dict>

--- a/Research/ResearchTests/Info-iOS.plist
+++ b/Research/ResearchTests/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 </dict>

--- a/Research/ResearchTests/ModelObject Tests/ColorPaletteTests.swift
+++ b/Research/ResearchTests/ModelObject Tests/ColorPaletteTests.swift
@@ -49,10 +49,10 @@ class ColorPaletteTests: XCTestCase {
         
         let palette = RSDColorPalette.wireframe
         
-        XCTAssertEqual(palette.text.index, 1)
+        XCTAssertEqual(palette.text.index, 2)
         
         let textKey = RSDColorMatrix.shared.colorKey(for: .special(.text), shade: .medium)
-        XCTAssertEqual(textKey.index, 1)
+        XCTAssertEqual(textKey.index, 2)
         
         let textSwatch = RSDColorMatrix.shared.colorSwatch(for: .special(.text), version: 0)
         XCTAssertNotNil(textSwatch)

--- a/Research/ResearchTests/ModelObject Tests/ColorRulesTests.swift
+++ b/Research/ResearchTests/ModelObject Tests/ColorRulesTests.swift
@@ -119,29 +119,27 @@ class ColorRulesTests: XCTestCase {
 
     func testTextColor() {
         let palette: RSDColorPalette = .wireframe
-        let colorRules = RSDColorRules(palette: palette)
+        let colorRules = RSDColorRules(palette: palette, version: 2)
         
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .heading1), palette.text.dark.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .heading2), palette.text.dark.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .heading3), palette.text.dark.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .heading4), palette.text.dark.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .fieldHeader), palette.text.dark.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .body), palette.text.dark.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .microHeader), palette.text.dark.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .counter), palette.text.dark.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .bodyDetail), palette.text.normal.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .small), palette.text.normal.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .xLargeHeader), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .largeHeader), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .mediumHeader), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .smallHeader), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .body), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .microHeader), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .largeNumber), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .bodyDetail), palette.text.dark.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.white, for: .small), palette.text.dark.color)
         
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .heading1), palette.text.light.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .heading2), palette.text.light.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .heading3), palette.text.light.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .heading4), palette.text.light.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .fieldHeader), palette.text.light.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .body), palette.text.light.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .microHeader), palette.text.light.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .counter), palette.text.light.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .bodyDetail), palette.text.light.color)
-        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .small), palette.text.light.color)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .xLargeHeader), UIColor.white)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .largeHeader), UIColor.white)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .mediumHeader), UIColor.white)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .smallHeader), UIColor.white)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .body), UIColor.white)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .microHeader), UIColor.white)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .largeNumber), UIColor.white)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .bodyDetail), UIColor.white)
+        XCTAssertEqual(colorRules.textColor(on: palette.grayScale.black, for: .small), UIColor.white)
     }
 
     func testTintedButtonColor_LightPrimary() {
@@ -165,38 +163,16 @@ class ColorRulesTests: XCTestCase {
         XCTAssertEqual(colorRules.tintedButtonColor(on: palette.primary.normal), UIColor.white)
         XCTAssertEqual(colorRules.tintedButtonColor(on: palette.successGreen.veryLight), palette.grayScale.veryDarkGray.color)
     }
-
-    func testUnderlinedTextButton_v0_LightPrimary() {
-        let palette: RSDColorPalette = .beach
-        let colorRules = RSDColorRules(palette: palette, version: 0)
-        
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.black, state: .normal), UIColor.white)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.white, state: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.veryLightGray, state: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.primary.normal, state: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.successGreen.veryLight, state: .normal), palette.text.dark.color)
-    }
-    
-    func testUnderlinedTextButton_v0_DarkPrimary() {
-        let palette: RSDColorPalette = .midnight
-        let colorRules = RSDColorRules(palette: palette, version: 0)
-        
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.black, state: .normal), UIColor.white)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.white, state: .normal), palette.primary.normal.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.veryLightGray, state: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.primary.normal, state: .normal), palette.text.light.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.successGreen.veryLight, state: .normal), palette.text.dark.color)
-    }
     
     func testUnderlinedTextButton_v1_LightPrimary() {
         let palette: RSDColorPalette = .beach
         let colorRules = RSDColorRules(palette: palette, version: 1)
         
         XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.black, state: .normal), UIColor.white)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.white, state: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.veryLightGray, state: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.primary.normal, state: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.successGreen.veryLight, state: .normal), palette.text.dark.color)
+        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.white, state: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.veryLightGray, state: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.primary.normal, state: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.successGreen.veryLight, state: .normal), palette.text.veryDark.color)
     }
     
     func testUnderlinedTextButton_v1_DarkPrimary() {
@@ -204,10 +180,10 @@ class ColorRulesTests: XCTestCase {
         let colorRules = RSDColorRules(palette: palette, version: 1)
         
         XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.black, state: .normal), UIColor.white)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.white, state: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.veryLightGray, state: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.primary.normal, state: .normal), palette.text.light.color)
-        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.successGreen.veryLight, state: .normal), palette.text.dark.color)
+        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.white, state: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.grayScale.veryLightGray, state: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.primary.normal, state: .normal), UIColor.white)
+        XCTAssertEqual(colorRules.underlinedTextButton(on: palette.successGreen.veryLight, state: .normal), palette.text.veryDark.color)
     }
 
     func testRoundedButton() {
@@ -244,40 +220,40 @@ class ColorRulesTests: XCTestCase {
         let palette: RSDColorPalette = .beach
         let colorRules = RSDColorRules(palette: palette)
         
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .normal), palette.text.dark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .normal), palette.text.veryDark.color)
         
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .highlighted), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .highlighted), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .highlighted), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .highlighted), palette.text.dark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .highlighted), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .highlighted), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .highlighted), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .highlighted), palette.text.veryDark.color)
         
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .disabled), palette.text.dark.color.withAlphaComponent(0.35))
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .disabled), palette.text.dark.color.withAlphaComponent(0.35))
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .disabled), palette.text.dark.color.withAlphaComponent(0.35))
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .disabled), palette.text.dark.color.withAlphaComponent(0.35))
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .disabled), palette.text.veryDark.color.withAlphaComponent(0.35))
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .disabled), palette.text.veryDark.color.withAlphaComponent(0.35))
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .disabled), palette.text.veryDark.color.withAlphaComponent(0.35))
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .disabled), palette.text.veryDark.color.withAlphaComponent(0.35))
     }
     
     func testRoundedButtonText_DarkSecondary() {
         let palette: RSDColorPalette = .midnight
         let colorRules = RSDColorRules(palette: palette)
         
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .normal), palette.text.light.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .normal), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .normal), palette.text.dark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .normal), palette.text.veryLight.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .normal), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .normal), palette.text.veryDark.color)
         
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .highlighted), palette.text.light.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .highlighted), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .highlighted), palette.text.dark.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .highlighted), palette.text.dark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .highlighted), palette.text.veryLight.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .highlighted), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .highlighted), palette.text.veryDark.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .highlighted), palette.text.veryDark.color)
         
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .disabled), palette.text.light.color)
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .disabled), palette.text.dark.color.withAlphaComponent(0.35))
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .disabled), palette.text.dark.color.withAlphaComponent(0.35))
-        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .disabled), palette.text.dark.color.withAlphaComponent(0.35))
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .primary, forState: .disabled), palette.text.veryLight.color)
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .primary, forState: .disabled), palette.text.veryDark.color.withAlphaComponent(0.35))
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.grayScale.white, with: .secondary, forState: .disabled), palette.text.veryDark.color.withAlphaComponent(0.35))
+        XCTAssertEqual(colorRules.roundedButtonText(on: palette.primary.normal, with: .secondary, forState: .disabled), palette.text.veryDark.color.withAlphaComponent(0.35))
     }
     
     func testCheckboxButton_LightColors() {

--- a/Research/ResearchUI/Info-iOS.plist
+++ b/Research/ResearchUI/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 </dict>

--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -374,7 +374,7 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
                 header.shouldShowProgress = true
                 header.progressView?.totalSteps = stepCount
                 header.progressView?.currentStep = stepIndex
-                header.stepCountLabel?.attributedText = header.progressView?.attributedStringForLabel()
+                header.stepCountLabel?.text = header.progressView?.stringForLabel()
                 header.isStepLabelHidden = isEstimated
             } else {
                 header.shouldShowProgress = false

--- a/Research/ResearchUI/iOS/Step View Controllers/RSDActiveStepViewController.swift
+++ b/Research/ResearchUI/iOS/Step View Controllers/RSDActiveStepViewController.swift
@@ -355,6 +355,22 @@ open class RSDActiveStepViewController: RSDFullscreenImageStepViewController {
         self.view.setNeedsUpdateConstraints()
     }
     
+    open override func setupViews() {
+        super.setupViews()
+        
+        self.doneLabel?.font = self.designSystem.fontRules.font(for: .largeNumber, compatibleWith: traitCollection)
+        self.unitLabel?.font = self.designSystem.fontRules.baseFont(for: .largeHeader)  // NOT DYNAMIC
+        self.instructionLabel?.font = self.designSystem.fontRules.font(for: .largeHeader, compatibleWith: traitCollection)
+        self.countdownLabel?.font = self.designSystem.fontRules.font(for: .largeNumber, compatibleWith: traitCollection)
+    }
+    
+    override open func setColorStyle(for placement: RSDColorPlacement, background: RSDColorTile) {
+        super.setColorStyle(for: placement, background: background)
+        
+        if placement == .body {
+            self.instructionLabel?.textColor = self.designSystem.colorRules.textColor(on: background, for: .largeHeader)
+        }
+    }
     
     // MARK: Initialization
     

--- a/Research/ResearchUI/iOS/Step View Controllers/RSDCountdownStepViewController.swift
+++ b/Research/ResearchUI/iOS/Step View Controllers/RSDCountdownStepViewController.swift
@@ -106,7 +106,7 @@ open class RSDCountdownStepViewController: RSDFullscreenImageStepViewController 
     
     /// Returns the color to use for the countdown label
     open func countdownLabelColor(on background: RSDColorTile) -> UIColor {
-        return self.designSystem.colorRules.textColor(on: background, for: .counter)
+        return self.designSystem.colorRules.textColor(on: background, for: .largeNumber)
     }
     
     // MARK: Initialization

--- a/Research/ResearchUI/iOS/Step View Controllers/RSDResultSummaryStepViewController.swift
+++ b/Research/ResearchUI/iOS/Step View Controllers/RSDResultSummaryStepViewController.swift
@@ -71,12 +71,20 @@ open class RSDResultSummaryStepViewController: RSDInstructionStepViewController 
         postAccessibilityAnnouncement()
     }
     
+    open override func setupViews() {
+        super.setupViews()
+        
+        self.resultTitleLabel?.font = self.designSystem.fontRules.baseFont(for: .largeHeader)
+        self.resultLabel?.font = self.designSystem.fontRules.baseFont(for: .largeNumber)
+        self.unitLabel?.font = self.designSystem.fontRules.baseFont(for: .largeHeader)
+    }
+    
     open override func setColorStyle(for placement: RSDColorPlacement, background: RSDColorTile) {
         super.setColorStyle(for: placement, background: background)
         
-        self.resultTitleLabel?.textColor = self.designSystem.colorRules.textColor(on: background, for: .fieldHeader)
-        self.resultLabel?.textColor = self.designSystem.colorRules.textColor(on: background, for: .counter)
-        self.unitLabel?.textColor = self.designSystem.colorRules.textColor(on: background, for: .counter)
+        self.resultTitleLabel?.textColor = self.designSystem.colorRules.textColor(on: background, for: .largeHeader)
+        self.resultLabel?.textColor = self.designSystem.colorRules.textColor(on: background, for: .largeNumber)
+        self.unitLabel?.textColor = self.designSystem.colorRules.textColor(on: background, for: .largeHeader)
     }
     
     open override func defaultBackgroundColorTile(for placement: RSDColorPlacement) -> RSDColorTile {

--- a/Research/ResearchUI/iOS/Step View Controllers/RSDScrollingOverviewStepViewController.swift
+++ b/Research/ResearchUI/iOS/Step View Controllers/RSDScrollingOverviewStepViewController.swift
@@ -166,8 +166,8 @@ open class RSDScrollingOverviewStepViewController: RSDOverviewStepViewController
             
             scrollView.backgroundColor = background.color
             iconViewLabel.text = Localization.localizedString("OVERVIEW_WHAT_YOU_NEED")
-            iconViewLabel.textColor = self.designSystem.colorRules.textColor(on: background, for: .fieldHeader)
-            iconViewLabel.font = self.designSystem.fontRules.font(for: .fieldHeader)
+            iconViewLabel.textColor = self.designSystem.colorRules.textColor(on: background, for: .mediumHeader)
+            iconViewLabel.font = self.designSystem.fontRules.font(for: .mediumHeader)
             
             let textColor = self.designSystem.colorRules.textColor(on: background, for: .microHeader)
             let font = self.designSystem.fontRules.font(for: .microHeader, compatibleWith: traitCollection)

--- a/Research/ResearchUI/iOS/Views/RSDCountdownDial.swift
+++ b/Research/ResearchUI/iOS/Views/RSDCountdownDial.swift
@@ -183,7 +183,8 @@ public final class RSDCountdownDial: RSDProgressIndicator, RSDViewDesignable {
         func recursiveLabelUpdate(_ view: UIView) {
             view.subviews.forEach {
                 if let label = $0 as? UILabel {
-                    label.textColor = designSystem.colorRules.textColor(on: colorRules.inner, for: .counter)
+                    // TODO: syoung 07/03/2019 Revisit setting the label color to match the font size.
+                    label.textColor = designSystem.colorRules.textColor(on: colorRules.inner, for: .largeNumber)
                 }
                 else if let stackView = $0 as? UIStackView {
                     recursiveLabelUpdate(stackView)

--- a/Research/ResearchUI/iOS/Views/RSDPickerViewProtocol.swift
+++ b/Research/ResearchUI/iOS/Views/RSDPickerViewProtocol.swift
@@ -119,8 +119,8 @@ extension RSDDatePickerMode {
 
 /// `RSDChoicePickerView` is a `UIPickerView` that can be used to represent a picker with an associated index path.
 /// This picker has a `RSDChoicePickerDataSource` as it's source. This implementation only supports text choices.
-open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerViewDataSource, UIPickerViewDelegate {
-    
+open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerViewDataSource, UIPickerViewDelegate, RSDViewDesignable {
+
     /// The observer of this picker
     public weak var observer: RSDPickerObserver?
     
@@ -310,8 +310,11 @@ open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerVi
     
     /// Instantiate a label for the given component.
     open func instantiateLabel(for component: Int) -> UILabel {
+        let designSystem = self.designSystem ?? RSDDesignSystem()
+        let background = self.backgroundColorTile ?? designSystem.colorRules.backgroundLight        
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 24)
+        label.font = designSystem.fontRules.font(for: .largeHeader)
+        label.textColor = designSystem.colorRules.textColor(on: background, for: .largeHeader)
         let isFirst = (component == 0)
         let isLast = (component + 1 == numberOfComponents)
         if numberOfComponents == 1 || !(isFirst || isLast) {
@@ -351,6 +354,16 @@ open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerVi
     private var _rowWidth: [Int: CGFloat] = [:]
     private var _rowHeight: CGFloat = 0
     
+    // MARK: Design System
+    
+    public private(set) var backgroundColorTile: RSDColorTile?
+    
+    public private(set) var designSystem: RSDDesignSystem?
+    
+    public func setDesignSystem(_ designSystem: RSDDesignSystem, with background: RSDColorTile) {
+        self.designSystem = designSystem
+        self.backgroundColorTile = background
+    }
 }
 
 /// `RSDNumberPickerView` is a `UIPickerView` that can be used to represent a picker with an associated index path.

--- a/Research/ResearchUI/iOS/Views/RSDRoundedButton.swift
+++ b/Research/ResearchUI/iOS/Views/RSDRoundedButton.swift
@@ -155,7 +155,7 @@ import UIKit
         }
         
         // Set the title font to the font for a rounded button.
-        titleLabel?.font = designSystem.fontRules.font(for: .heading4)
+        titleLabel?.font = designSystem.fontRules.font(for: .mediumHeader)
     }
     
     public required init() {

--- a/Research/ResearchUI/iOS/Views/RSDRoundedToggleButton.swift
+++ b/Research/ResearchUI/iOS/Views/RSDRoundedToggleButton.swift
@@ -93,13 +93,11 @@ open class RSDRoundedToggleButton : UIButton, RSDViewDesignable {
         let designSystem = self.designSystem ?? RSDDesignSystem()
         let colorTile: RSDColorTile = self.backgroundTile() ?? designSystem.colorRules.backgroundLight
         
-        // Set the title font for whether or not the button is selected.
-        titleLabel?.font = isSelected ? UIFont.boldSystemFont(ofSize: 16) : UIFont.systemFont(ofSize: 16)
-        
-        // Set the background to the current state. iOS 11 does not support setting the background of the
-        // button based on the button state.
+        // Set the background and font to the current state.
+        // iOS 11 does not support setting these based on the button state.
         let currentState: RSDControlState = (isHighlighted ? .highlighted : isSelected ? .selected : .normal)
         self.backgroundColor = designSystem.colorRules.roundedButton(on: colorTile, with: .secondary, forState: currentState)
+        titleLabel?.font = designSystem.fontRules.buttonFont(for: .toggle, state: currentState)
     }
     
     public required init() {

--- a/Research/ResearchUI/iOS/Views/RSDStepChoiceCell.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepChoiceCell.swift
@@ -47,8 +47,8 @@ import UIKit
         }
     }
     
-    open private(set) var titleTextType: RSDDesignSystem.TextType = .body
-    open private(set) var detailTextType: RSDDesignSystem.TextType = .small
+    open private(set) var titleTextType: RSDDesignSystem.TextType = .small
+    open private(set) var detailTextType: RSDDesignSystem.TextType = .bodyDetail
     
     func updateColorsAndFonts() {
         let designSystem = self.designSystem ?? RSDDesignSystem()

--- a/Research/ResearchUI/iOS/Views/RSDStepNavigationView.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepNavigationView.swift
@@ -212,7 +212,7 @@ open class RSDStepNavigationView: UIView, RSDViewDesignable {
         self.recursiveSetDesignSystem(designSystem, with: background)
         
         // Set the fonts for the labels
-        titleLabel?.font = designSystem.fontRules.font(for: .heading2, compatibleWith: self.traitCollection)
+        titleLabel?.font = designSystem.fontRules.font(for: .largeHeader, compatibleWith: self.traitCollection)
         textLabel?.font = designSystem.fontRules.font(for: .body, compatibleWith: self.traitCollection)
         detailLabel?.font = designSystem.fontRules.font(for: .bodyDetail, compatibleWith: self.traitCollection)
         
@@ -228,7 +228,7 @@ open class RSDStepNavigationView: UIView, RSDViewDesignable {
         }()
         
         self.tintColor = designSystem.colorRules.tintedButtonColor(on: colorTile)
-        titleLabel?.textColor = designSystem.colorRules.textColor(on: colorTile, for: .heading2)
+        titleLabel?.textColor = designSystem.colorRules.textColor(on: colorTile, for: .largeHeader)
         textLabel?.textColor = designSystem.colorRules.textColor(on: colorTile, for: .body)
         detailLabel?.textColor = designSystem.colorRules.textColor(on: colorTile, for: .bodyDetail)
     }

--- a/Research/ResearchUI/iOS/Views/RSDStepProgressView.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepProgressView.swift
@@ -112,8 +112,8 @@ open class RSDStepProgressView: UIView, RSDViewDesignable {
         let rules = designSystem.colorRules.progressBar(on: colorTile)
         progressView.backgroundColor = rules.filled
         backgroundView.backgroundColor = rules.unfilled
-        stepCountLabel?.textColor = designSystem.colorRules.textColor(on: colorTile, for: .small)
-        stepCountLabel?.font = designSystem.fontRules.font(for: .small)
+        stepCountLabel?.textColor = designSystem.colorRules.textColor(on: colorTile, for: .microHeader)
+        stepCountLabel?.font = designSystem.fontRules.font(for: .microHeader)
     }
 
     /// The height of the actual progress bar.
@@ -138,16 +138,20 @@ open class RSDStepProgressView: UIView, RSDViewDesignable {
         return self.totalSteps > 0
     }
     
-    /// The text of the label that is displayed directly under the progress bar.
+    @available(*, unavailable)
     open func attributedStringForLabel() -> NSAttributedString? {
+        return nil
+    }
+    
+    /// The text of the label that is displayed directly under the progress bar.
+    open func stringForLabel() -> String? {
         if currentStep > 0 && totalSteps > 0 {
             let formatter = NumberFormatter()
             formatter.numberStyle = .none
             let currentString = formatter.string(for: currentStep)!
             let totalString = formatter.string(for: totalSteps)!
             let format = Localization.localizedString("CURRENT_STEP_%@_OF_TOTAL_STEPS_%@")
-            let str = String.localizedStringWithFormat(format, currentString, totalString)
-            return NSAttributedString(string: str)
+            return String.localizedStringWithFormat(format, currentString, totalString)
         }
         else {
             return nil
@@ -237,6 +241,6 @@ open class RSDStepProgressView: UIView, RSDViewDesignable {
     /// Sets the text of the progress view label.
     /// Default = attributedStringForLabel()
     open func updateLabel() {
-        stepCountLabel?.attributedText = attributedStringForLabel()
+        stepCountLabel?.text = stringForLabel()
     }
 }

--- a/Research/ResearchUI/iOS/Views/RSDStepTextFieldCell.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepTextFieldCell.swift
@@ -58,7 +58,7 @@ open class RSDStepTextFieldCell: RSDTableViewCell {
         fieldLabel = UILabel()
     }
     
-    open private(set) var fieldLabelTextType: RSDDesignSystem.TextType = .small
+    open private(set) var fieldLabelTextType: RSDDesignSystem.TextType = .microHeader
     open private(set) var textfieldTextType: RSDDesignSystem.TextType = .body
     
     override open var usesTableBackgroundColor: Bool {
@@ -202,7 +202,7 @@ open class RSDStepTextViewCell: RSDTableViewCell {
         updateColorsAndFonts()
     }
     
-    open private(set) var fieldLabelTextType: RSDDesignSystem.TextType = .small
+    open private(set) var fieldLabelTextType: RSDDesignSystem.TextType = .microHeader
     open private(set) var textViewTextType: RSDDesignSystem.TextType = .body
     
     override open var usesTableBackgroundColor: Bool {
@@ -323,7 +323,7 @@ extension RSDDefaultStepTextViewCellLayoutConstants : RSDStepTextViewCellLayoutC
 open class RSDStepTextFieldFeaturedCell: RSDStepTextFieldCell {
     
     override open var textfieldTextType: RSDDesignSystem.TextType {
-        return .heading1
+        return .largeBody
     }
     
     /// Override `setupViews()` to change alignment and set the field label hidden.

--- a/Research/ResearchUI/iOS/Views/RSDTableSectionHeader.swift
+++ b/Research/ResearchUI/iOS/Views/RSDTableSectionHeader.swift
@@ -41,8 +41,8 @@ import Foundation
     @IBOutlet open var detailLabel: UILabel!
     @IBOutlet open var separatorLine: UIView?
     
-    open private(set) var titleTextType: RSDDesignSystem.TextType = .fieldHeader
-    open private(set) var detailTextType: RSDDesignSystem.TextType = .small
+    open private(set) var titleTextType: RSDDesignSystem.TextType = .mediumHeader
+    open private(set) var detailTextType: RSDDesignSystem.TextType = .bodyDetail
     
     /// The background color for the table section.
     open private(set) var backgroundColorTile: RSDColorTile?

--- a/Research/ResearchUI/iOS/Views/RSDTextLabelCell.swift
+++ b/Research/ResearchUI/iOS/Views/RSDTextLabelCell.swift
@@ -101,7 +101,7 @@ import Foundation
     func updateColorAndFont() {
         guard let colorTile = self.backgroundColorTile else { return }
         let designSystem = self.designSystem ?? RSDDesignSystem()
-        label.font = designSystem.fontRules.font(for: .small, compatibleWith: traitCollection)
-        label.textColor = designSystem.colorRules.textColor(on: colorTile, for: .small)
+        label.font = designSystem.fontRules.font(for: .microDetail, compatibleWith: traitCollection)
+        label.textColor = designSystem.colorRules.textColor(on: colorTile, for: .microDetail)
     }
 }

--- a/Research/ResearchUI/iOS/Views/RSDUnderlinedButton.swift
+++ b/Research/ResearchUI/iOS/Views/RSDUnderlinedButton.swift
@@ -44,9 +44,17 @@ import UIKit
         }
     }
 
-    /// The font used for the text button.
-    @IBInspectable open var textFont : UIFont = UIFont.systemFont(ofSize: 18) {
+    @IBInspectable
+    open var isHeaderLink: Bool = false {
         didSet {
+            refreshView()
+        }
+    }
+    
+    @available(*, deprecated)
+    open var textFont : UIFont? {
+        didSet {
+            debugPrint("WARNING! Setting a deprecated property on RSDUnderlinedButton. Likely using a NIB or storyboard.")
             refreshView()
         }
     }
@@ -92,13 +100,19 @@ import UIKit
     /// Create an attributed string for this class.
     private func attributedString(_ title: String?, for state: UIControl.State) -> NSAttributedString? {
        
+        let controlState = RSDControlState(controlState: state)
+        let designSystem = self.designSystem ?? RSDDesignSystem()
+        let buttonType: RSDDesignSystem.ButtonType = self.isHeaderLink ? .headerLink : .bodyLink
+        
         let foregroundColor: UIColor = {
-            guard let designSystem = self.designSystem, let background = self.backgroundColorTile
+            guard let background = self.backgroundColorTile
                 else {
                     return self.tintColor
             }
-            return designSystem.colorRules.underlinedTextButton(on: background, state: RSDControlState(controlState: state))
+            return designSystem.colorRules.underlinedTextButton(on: background, state: controlState)
         }()
+        
+        let textFont = self.textFont ?? designSystem.fontRules.buttonFont(for: buttonType, state: controlState)
         
         if let titleUnwrapped = title {
             let attributes: [NSAttributedString.Key : Any] = [

--- a/Research/ResearchUITests/Info.plist
+++ b/Research/ResearchUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.2</string>
 	<key>CFBundleVersion</key>
 	<string>50</string>
 </dict>


### PR DESCRIPTION
Went through all the screens that are standard within this framework and attempted to match to the
updated Design System.

Note: This does not include using the Lato font. That is not one of the fonts that is installed on iPhones by default and looks like embedding it means updating the app's info.plist. Will look into it further, but definitely non-trivial.

This will allow apps that install the Lato font to implement overrides to the base rules.