### PR TITLE
Update fonts to use dynamic font sizing

### DIFF
--- a/RSDCatalog/RSDCatalog/JSON Files/Recorder_Motion.json
+++ b/RSDCatalog/RSDCatalog/JSON Files/Recorder_Motion.json
@@ -23,7 +23,7 @@
                                                {
                                                "identifier"   : "instruction",
                                                "type"         : "instruction",
-                                               "title"        : "Please hold your phone",
+                                               "title"        : "Hold your phone",
                                                "text"         : "After the countdown, shake your phone. This will record the calculated gravity vector and the raw gyro data.",
                                                "image": {
                                                    "type": "fetchable",

--- a/Research/ResearchUI/iOS/Step View Controllers/RSDScrollingOverviewStepViewController.swift
+++ b/Research/ResearchUI/iOS/Step View Controllers/RSDScrollingOverviewStepViewController.swift
@@ -167,7 +167,7 @@ open class RSDScrollingOverviewStepViewController: RSDOverviewStepViewController
             scrollView.backgroundColor = background.color
             iconViewLabel.text = Localization.localizedString("OVERVIEW_WHAT_YOU_NEED")
             iconViewLabel.textColor = self.designSystem.colorRules.textColor(on: background, for: .mediumHeader)
-            iconViewLabel.font = self.designSystem.fontRules.font(for: .mediumHeader)
+            iconViewLabel.font = self.designSystem.fontRules.font(for: .mediumHeader, compatibleWith: traitCollection)
             
             let textColor = self.designSystem.colorRules.textColor(on: background, for: .microHeader)
             let font = self.designSystem.fontRules.font(for: .microHeader, compatibleWith: traitCollection)

--- a/Research/ResearchUI/iOS/Views/RSDPickerViewProtocol.swift
+++ b/Research/ResearchUI/iOS/Views/RSDPickerViewProtocol.swift
@@ -313,7 +313,7 @@ open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerVi
         let designSystem = self.designSystem ?? RSDDesignSystem()
         let background = self.backgroundColorTile ?? designSystem.colorRules.backgroundLight        
         let label = UILabel()
-        label.font = designSystem.fontRules.font(for: .largeHeader)
+        label.font = designSystem.fontRules.baseFont(for: .largeHeader)
         label.textColor = designSystem.colorRules.textColor(on: background, for: .largeHeader)
         let isFirst = (component == 0)
         let isLast = (component + 1 == numberOfComponents)

--- a/Research/ResearchUI/iOS/Views/RSDRoundedButton.swift
+++ b/Research/ResearchUI/iOS/Views/RSDRoundedButton.swift
@@ -155,7 +155,7 @@ import UIKit
         }
         
         // Set the title font to the font for a rounded button.
-        titleLabel?.font = designSystem.fontRules.font(for: .mediumHeader)
+        titleLabel?.font = designSystem.fontRules.buttonFont(for: buttonType, state: .normal)
     }
     
     public required init() {

--- a/Research/ResearchUI/iOS/Views/RSDStepProgressView.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepProgressView.swift
@@ -113,7 +113,7 @@ open class RSDStepProgressView: UIView, RSDViewDesignable {
         progressView.backgroundColor = rules.filled
         backgroundView.backgroundColor = rules.unfilled
         stepCountLabel?.textColor = designSystem.colorRules.textColor(on: colorTile, for: .microHeader)
-        stepCountLabel?.font = designSystem.fontRules.font(for: .microHeader)
+        stepCountLabel?.font = designSystem.fontRules.font(for: .microHeader, compatibleWith: traitCollection)
     }
 
     /// The height of the actual progress bar.


### PR DESCRIPTION
Note: This does not include other accessibility settings that are included in the settings app, but will extend the Sage Design System to accommodate users who prefer a different text size for copy text from the default for UI/UX elements that should be dynamic.

To test this feature, toggle the "Larger Text" accessibility setting. For super-huge text, this is a 3x ratio which means we should probably talk about updating the rules for setting up constraints on some of the views. That said, it sure makes it easier for me to read the instruction text on device. ;)