### PR TITLE
Update countdown step view to match new designs

### DIFF
--- a/Research/ResearchUI/iOS/Step View Controllers/Default NIbs/RSDCountdownStepViewController.xib
+++ b/Research/ResearchUI/iOS/Step View Controllers/Default NIbs/RSDCountdownStepViewController.xib
@@ -12,157 +12,97 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RSDCountdownStepViewController" customModule="ResearchUI" customModuleProvider="target">
             <connections>
-                <outlet property="countdownLabel" destination="Af7-QE-ZV6" id="xZx-jN-hk4"/>
-                <outlet property="navigationHeader" destination="d6T-5w-AqF" id="gRb-ah-h5D"/>
-                <outlet property="pauseButton" destination="TqA-Ca-ZKl" id="kGJ-Ps-h3S"/>
-                <outlet property="view" destination="LFa-08-RaT" id="B0f-AM-ZKb"/>
+                <outlet property="countdownLabel" destination="jeF-2k-yOO" id="ooj-CC-aCm"/>
+                <outlet property="pauseButton" destination="0NN-9M-6c6" id="JoM-bD-eXN"/>
+                <outlet property="statusBarBackgroundView" destination="7hT-Sf-hud" id="pfv-gb-OD0"/>
+                <outlet property="view" destination="1WE-Q4-TBa" id="M7a-aI-cgi"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="LFa-08-RaT" customClass="RSDStepNavigationView" customModule="ResearchUI" customModuleProvider="target">
+        <view contentMode="scaleToFill" id="1WE-Q4-TBa" customClass="RSDStepHeaderView" customModule="ResearchUI">
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" alpha="0.29999999999999999" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="88B-5u-ohK">
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.30000001192092896" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="900" translatesAutoresizingMaskIntoConstraints="NO" id="Tqa-iw-q7M" userLabel="Image View">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                 </imageView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d6T-5w-AqF" userLabel="Header" customClass="RSDStepHeaderView" customModule="ResearchUI" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="32" width="375" height="222.5"/>
-                    <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qef-96-GMe" userLabel="Navigation Header">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="63"/>
-                            <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LaD-KT-cpv">
-                                    <rect key="frame" x="8" y="-9" width="50" height="50"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" secondItem="LaD-KT-cpv" secondAttribute="height" multiplier="1:1" id="CPk-aR-Jfm"/>
-                                        <constraint firstAttribute="width" constant="50" id="uWg-uB-X4t"/>
-                                    </constraints>
-                                    <state key="normal" image="closeActivity"/>
-                                    <connections>
-                                        <action selector="cancel" destination="-1" eventType="touchUpInside" id="Ntc-yQ-Svi"/>
-                                    </connections>
-                                </button>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="igH-QR-FOm" customClass="RSDStepProgressView" customModule="ResearchUI" customModuleProvider="target">
-                                    <rect key="frame" x="74" y="11" width="285" height="10"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="10" id="1pI-YG-dE2"/>
-                                    </constraints>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="hasRoundedEnds" value="YES"/>
-                                    </userDefinedRuntimeAttributes>
-                                    <connections>
-                                        <outlet property="stepCountLabel" destination="FdT-WA-Sq6" id="Mhh-Iz-g7g"/>
-                                    </connections>
-                                </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Step 1 of 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FdT-WA-Sq6">
-                                    <rect key="frame" x="149.5" y="46" width="76" height="17"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                    <color key="textColor" red="0.19607843137254902" green="0.21568627450980393" blue="0.27843137254901962" alpha="1" colorSpace="calibratedRGB"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                            </subviews>
-                            <constraints>
-                                <constraint firstItem="FdT-WA-Sq6" firstAttribute="centerX" secondItem="qef-96-GMe" secondAttribute="centerX" id="3Fu-AY-hxZ"/>
-                                <constraint firstItem="LaD-KT-cpv" firstAttribute="leading" secondItem="qef-96-GMe" secondAttribute="leading" constant="8" id="3MC-VY-Mny"/>
-                                <constraint firstItem="igH-QR-FOm" firstAttribute="leading" secondItem="LaD-KT-cpv" secondAttribute="trailing" constant="16" id="8qs-Be-rFU"/>
-                                <constraint firstAttribute="trailing" secondItem="igH-QR-FOm" secondAttribute="trailing" constant="16" id="FOL-Uy-Vow"/>
-                                <constraint firstItem="igH-QR-FOm" firstAttribute="centerY" secondItem="LaD-KT-cpv" secondAttribute="centerY" id="UC7-IL-d9B"/>
-                                <constraint firstItem="FdT-WA-Sq6" firstAttribute="top" secondItem="LaD-KT-cpv" secondAttribute="bottom" constant="5" id="cbE-Xo-7oR"/>
-                                <constraint firstAttribute="bottom" secondItem="FdT-WA-Sq6" secondAttribute="bottom" id="ggZ-6d-zvw"/>
-                                <constraint firstItem="LaD-KT-cpv" firstAttribute="top" secondItem="qef-96-GMe" secondAttribute="top" constant="-9" id="nWb-AP-mCH"/>
-                            </constraints>
-                        </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start in" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Vo-ap-GH7">
-                            <rect key="frame" x="24" y="119" width="327" height="26.5"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                            <color key="textColor" red="0.47843137254901957" green="0.50196078431372548" blue="0.56470588235294117" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aqM-Sh-4ad" userLabel="Cancel Button">
+                    <rect key="frame" x="20" y="40" width="50" height="50"/>
                     <constraints>
-                        <constraint firstAttribute="bottom" secondItem="8Vo-ap-GH7" secondAttribute="bottom" constant="77" id="H6n-Ae-h2n"/>
-                        <constraint firstAttribute="trailing" secondItem="8Vo-ap-GH7" secondAttribute="trailing" constant="24" id="KJD-jw-SUG"/>
-                        <constraint firstItem="qef-96-GMe" firstAttribute="leading" secondItem="d6T-5w-AqF" secondAttribute="leading" id="UOr-3c-xMY"/>
-                        <constraint firstItem="8Vo-ap-GH7" firstAttribute="leading" secondItem="d6T-5w-AqF" secondAttribute="leading" constant="24" id="WRw-3B-WpT"/>
-                        <constraint firstAttribute="trailing" secondItem="qef-96-GMe" secondAttribute="trailing" id="dzd-N7-HnZ"/>
-                        <constraint firstItem="8Vo-ap-GH7" firstAttribute="top" secondItem="qef-96-GMe" secondAttribute="bottom" constant="56" id="eBe-yY-4EF"/>
-                        <constraint firstItem="qef-96-GMe" firstAttribute="top" secondItem="d6T-5w-AqF" secondAttribute="top" id="qKQ-J6-I1r"/>
+                        <constraint firstAttribute="width" secondItem="aqM-Sh-4ad" secondAttribute="height" multiplier="1:1" id="J4Z-mB-pHQ"/>
                     </constraints>
+                    <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <state key="normal" image="closeActivity"/>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0NN-9M-6c6" userLabel="Pause Button" customClass="RSDRoundedButton" customModule="ResearchUI">
+                    <rect key="frame" x="28" y="521.5" width="319" height="52"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                    <state key="normal" title="Pause">
+                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="isSecondaryButton" value="YES"/>
+                    </userDefinedRuntimeAttributes>
                     <connections>
-                        <outlet property="cancelButton" destination="LaD-KT-cpv" id="3lk-pN-MAz"/>
-                        <outlet property="progressView" destination="igH-QR-FOm" id="tzA-5S-WXC"/>
-                        <outlet property="stepCountLabel" destination="FdT-WA-Sq6" id="3WX-xX-xJ0"/>
-                        <outlet property="textLabel" destination="8Vo-ap-GH7" id="mKr-DZ-Axd"/>
+                        <action selector="pauseTimer" destination="-1" eventType="touchUpInside" id="QGL-nZ-QEi"/>
                     </connections>
-                </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DFQ-JA-Sc8" userLabel="Footer">
-                    <rect key="frame" x="0.0" y="583.5" width="375" height="83.5"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TqA-Ca-ZKl" customClass="RSDUnderlinedButton" customModule="ResearchUI" customModuleProvider="target">
-                            <rect key="frame" x="162.5" y="0.0" width="50" height="33.5"/>
-                            <state key="normal" title="Pause"/>
-                            <connections>
-                                <action selector="pauseTimer" destination="-1" eventType="touchUpInside" id="Hf3-Ox-f5K"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                </button>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jeF-2k-yOO" userLabel="Countdown Label">
+                    <rect key="frame" x="158.5" y="293.5" width="58" height="80"/>
                     <constraints>
-                        <constraint firstItem="TqA-Ca-ZKl" firstAttribute="centerX" secondItem="DFQ-JA-Sc8" secondAttribute="centerX" id="Ixb-uO-Gmi"/>
-                        <constraint firstAttribute="bottom" secondItem="TqA-Ca-ZKl" secondAttribute="bottomMargin" constant="58" id="Qy6-Qb-na3"/>
-                        <constraint firstItem="TqA-Ca-ZKl" firstAttribute="top" secondItem="DFQ-JA-Sc8" secondAttribute="top" id="mBY-U7-34c"/>
+                        <constraint firstAttribute="height" constant="80" id="CfF-Ir-te3"/>
                     </constraints>
-                </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ye0-7C-vxz">
-                    <rect key="frame" x="0.0" y="419" width="375" height="164.5"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n20-fF-k86">
-                    <rect key="frame" x="0.0" y="254.5" width="375" height="164.5"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Af7-QE-ZV6">
-                            <rect key="frame" x="150" y="4.5" width="75.5" height="155.5"/>
-                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="130"/>
-                            <color key="textColor" red="0.35686274509803922" green="0.6705882352941176" blue="0.33725490196078434" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstItem="Af7-QE-ZV6" firstAttribute="centerX" secondItem="n20-fF-k86" secondAttribute="centerX" id="Exb-84-aBW"/>
-                        <constraint firstItem="Af7-QE-ZV6" firstAttribute="centerY" secondItem="n20-fF-k86" secondAttribute="centerY" id="fiw-58-kdA"/>
-                    </constraints>
+                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="100"/>
+                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Begin in..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wNP-Fq-dc4" userLabel="Text Label">
+                    <rect key="frame" x="132" y="240.5" width="111" height="29"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
+                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="td1-5c-r9B" customClass="RSDUnderlinedButton" customModule="ResearchUI">
+                    <rect key="frame" x="108.5" y="603.5" width="158" height="33.5"/>
+                    <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <state key="normal" title="Review Instructions"/>
+                </button>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7hT-Sf-hud" customClass="RSDStatusBarBackgroundView" customModule="ResearchUI">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="20"/>
+                    <color key="backgroundColor" red="0.35294117650000001" green="0.2784313725" blue="0.56078431370000004" alpha="1" colorSpace="deviceRGB"/>
                 </view>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-            <color key="tintColor" red="0.11764705882352941" green="0.50196078431372548" blue="0.94117647058823528" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="0.32568424940000001" green="0.25694268939999998" blue="0.52321022750000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="ye0-7C-vxz" firstAttribute="height" secondItem="n20-fF-k86" secondAttribute="height" id="20w-GI-1Ci"/>
-                <constraint firstItem="n20-fF-k86" firstAttribute="top" secondItem="d6T-5w-AqF" secondAttribute="bottom" id="Gwf-jz-Flr"/>
-                <constraint firstItem="n20-fF-k86" firstAttribute="leading" secondItem="sWQ-zb-13H" secondAttribute="leading" id="LvU-HW-V6S"/>
-                <constraint firstItem="DFQ-JA-Sc8" firstAttribute="bottom" secondItem="sWQ-zb-13H" secondAttribute="bottom" id="M4f-0c-vsX"/>
-                <constraint firstItem="88B-5u-ohK" firstAttribute="trailing" secondItem="sWQ-zb-13H" secondAttribute="trailing" id="SQt-AC-cMj"/>
-                <constraint firstItem="DFQ-JA-Sc8" firstAttribute="top" secondItem="ye0-7C-vxz" secondAttribute="bottom" id="WvU-bB-ufQ"/>
-                <constraint firstItem="88B-5u-ohK" firstAttribute="top" secondItem="LFa-08-RaT" secondAttribute="top" id="b91-SH-bnm"/>
-                <constraint firstItem="88B-5u-ohK" firstAttribute="bottom" secondItem="sWQ-zb-13H" secondAttribute="bottom" id="bid-qk-Q5Y"/>
-                <constraint firstItem="d6T-5w-AqF" firstAttribute="leading" secondItem="sWQ-zb-13H" secondAttribute="leading" id="d2X-6L-h0Q"/>
-                <constraint firstItem="d6T-5w-AqF" firstAttribute="trailing" secondItem="sWQ-zb-13H" secondAttribute="trailing" id="dRg-Xw-0rD"/>
-                <constraint firstItem="88B-5u-ohK" firstAttribute="leading" secondItem="sWQ-zb-13H" secondAttribute="leading" id="gzq-ZA-ok5"/>
-                <constraint firstItem="ye0-7C-vxz" firstAttribute="top" secondItem="n20-fF-k86" secondAttribute="bottom" id="hCr-hR-rcO"/>
-                <constraint firstItem="DFQ-JA-Sc8" firstAttribute="trailing" secondItem="sWQ-zb-13H" secondAttribute="trailing" id="m0g-aY-l1z"/>
-                <constraint firstItem="ye0-7C-vxz" firstAttribute="trailing" secondItem="sWQ-zb-13H" secondAttribute="trailing" id="oHm-Fu-9vI"/>
-                <constraint firstItem="n20-fF-k86" firstAttribute="trailing" secondItem="sWQ-zb-13H" secondAttribute="trailing" id="p6M-Sg-aRi"/>
-                <constraint firstItem="ye0-7C-vxz" firstAttribute="leading" secondItem="sWQ-zb-13H" secondAttribute="leading" id="qBx-OR-HhX"/>
-                <constraint firstItem="d6T-5w-AqF" firstAttribute="top" secondItem="sWQ-zb-13H" secondAttribute="top" constant="12" id="wi9-f8-eYw"/>
-                <constraint firstItem="DFQ-JA-Sc8" firstAttribute="leading" secondItem="sWQ-zb-13H" secondAttribute="leading" id="zZm-dG-LgX"/>
+                <constraint firstItem="jeF-2k-yOO" firstAttribute="centerX" secondItem="1WE-Q4-TBa" secondAttribute="centerX" id="0gI-zr-UCi"/>
+                <constraint firstItem="Tqa-iw-q7M" firstAttribute="bottom" secondItem="1WE-Q4-TBa" secondAttribute="bottom" id="2KL-pA-EyU"/>
+                <constraint firstItem="Tqa-iw-q7M" firstAttribute="top" secondItem="1WE-Q4-TBa" secondAttribute="top" id="AyH-9M-9Kt"/>
+                <constraint firstItem="td1-5c-r9B" firstAttribute="bottom" secondItem="gfg-Vr-xUd" secondAttribute="bottom" constant="-30" id="BJh-Ub-bJ7"/>
+                <constraint firstItem="7hT-Sf-hud" firstAttribute="top" secondItem="1WE-Q4-TBa" secondAttribute="top" id="D1T-QM-B0J"/>
+                <constraint firstItem="aqM-Sh-4ad" firstAttribute="width" secondItem="aqM-Sh-4ad" secondAttribute="height" multiplier="1:1" id="DDp-N3-vgw"/>
+                <constraint firstItem="td1-5c-r9B" firstAttribute="centerX" secondItem="1WE-Q4-TBa" secondAttribute="centerX" id="FgJ-Am-UUD"/>
+                <constraint firstItem="0NN-9M-6c6" firstAttribute="leading" secondItem="gfg-Vr-xUd" secondAttribute="leading" constant="28" id="JPk-7O-BHP"/>
+                <constraint firstItem="jeF-2k-yOO" firstAttribute="centerY" secondItem="1WE-Q4-TBa" secondAttribute="centerY" id="K8U-FB-kTp"/>
+                <constraint firstItem="gfg-Vr-xUd" firstAttribute="leading" secondItem="aqM-Sh-4ad" secondAttribute="leading" constant="-20" id="O8t-8N-Oq4"/>
+                <constraint firstItem="0NN-9M-6c6" firstAttribute="trailing" secondItem="gfg-Vr-xUd" secondAttribute="trailing" constant="-28" id="RTp-37-Enu"/>
+                <constraint firstItem="jeF-2k-yOO" firstAttribute="top" secondItem="wNP-Fq-dc4" secondAttribute="bottom" constant="24" id="TpZ-EZ-Jwc"/>
+                <constraint firstItem="gfg-Vr-xUd" firstAttribute="top" secondItem="aqM-Sh-4ad" secondAttribute="top" constant="-20" id="VTv-bV-TcL"/>
+                <constraint firstItem="gfg-Vr-xUd" firstAttribute="top" secondItem="7hT-Sf-hud" secondAttribute="bottom" id="bc1-ws-Ygo"/>
+                <constraint firstItem="wNP-Fq-dc4" firstAttribute="centerX" secondItem="1WE-Q4-TBa" secondAttribute="centerX" id="dmO-9w-uVE"/>
+                <constraint firstItem="7hT-Sf-hud" firstAttribute="leading" secondItem="1WE-Q4-TBa" secondAttribute="leading" id="e01-ba-gBU"/>
+                <constraint firstAttribute="trailing" secondItem="7hT-Sf-hud" secondAttribute="trailing" id="enR-1W-9TZ"/>
+                <constraint firstItem="td1-5c-r9B" firstAttribute="top" secondItem="0NN-9M-6c6" secondAttribute="bottom" constant="30" id="f05-Nm-XRv"/>
+                <constraint firstItem="Tqa-iw-q7M" firstAttribute="leading" secondItem="1WE-Q4-TBa" secondAttribute="leading" id="fCw-9a-wOm"/>
+                <constraint firstItem="0NN-9M-6c6" firstAttribute="centerX" secondItem="1WE-Q4-TBa" secondAttribute="centerX" id="gE9-VK-Hhg"/>
+                <constraint firstItem="Tqa-iw-q7M" firstAttribute="trailing" secondItem="1WE-Q4-TBa" secondAttribute="trailing" id="v8E-aD-vBi"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="sWQ-zb-13H"/>
+            <viewLayoutGuide key="safeArea" id="gfg-Vr-xUd"/>
             <connections>
-                <outlet property="imageView" destination="88B-5u-ohK" id="GgD-gb-EAL"/>
+                <outlet property="cancelButton" destination="aqM-Sh-4ad" id="qNK-ik-xvH"/>
+                <outlet property="imageView" destination="Tqa-iw-q7M" id="1lt-Yl-0QT"/>
+                <outlet property="reviewInstructionsButton" destination="td1-5c-r9B" id="mZp-J7-gmo"/>
+                <outlet property="textLabel" destination="wNP-Fq-dc4" id="aCm-sx-7NK"/>
             </connections>
-            <point key="canvasLocation" x="138.40000000000001" y="154.27286356821591"/>
         </view>
     </objects>
     <resources>

--- a/Research/ResearchUI/iOS/Step View Controllers/RSDCountdownStepViewController.swift
+++ b/Research/ResearchUI/iOS/Step View Controllers/RSDCountdownStepViewController.swift
@@ -101,6 +101,9 @@ open class RSDCountdownStepViewController: RSDFullscreenImageStepViewController 
         super.setColorStyle(for: placement, background: background)
         if placement == .body {
             countdownLabel?.textColor = countdownLabelColor(on: background)
+            countdownLabel?.font = self.designSystem.fontRules.font(for: .largeNumber, compatibleWith: traitCollection)
+            self.pauseButton?.setTitle(Localization.buttonPause(), for: .normal)
+            (self.pauseButton as? RSDViewDesignable)?.setDesignSystem(self.designSystem, with: background)
         }
     }
     


### PR DESCRIPTION
Replace the previous design with the newer one used for the Motor Control module.

Jordon is currently working on designing these views to match MotorControl rather than CRF so use the designs in that module as the default.

Note: I decided against trying to version and standardize this at this time. With SwiftUI on the horizon, that's a better target to use for a full overhaul.