### PR TITLE
MP2-191 Start the recorder when the step timer starts

### DIFF
--- a/Research/Research-UnitTest/NavigationTestObjects.swift
+++ b/Research/Research-UnitTest/NavigationTestObjects.swift
@@ -249,6 +249,10 @@ public class TestAsyncActionController: NSObject, RSDAsyncAction {
         self.taskViewModel = taskViewModel
         super.init()
     }
+    
+    func requestPermission() {
+        status = .permissionGranted
+    }
 
     public func requestPermissions(on viewController: UIViewController, _ completion: @escaping RSDAsyncActionCompletionHandler) {
         status = .permissionGranted
@@ -307,6 +311,8 @@ public class TestTaskController: NSObject, RSDTaskController {
     public var addAsyncActions_calledWith: [RSDAsyncActionConfiguration]?
     public var startAsyncActions_called = false
     public var startAsyncActions_calledWith: [RSDAsyncAction]?
+    public var requestPermissionsForAsyncActions_called = false
+    public var requestPermissionsForAsyncActions_calledWith: [RSDAsyncAction]?
     public var stopAsyncActions_called = false
     public var stopAsyncActions_calledWith: [RSDAsyncAction]?
     
@@ -367,6 +373,24 @@ public class TestTaskController: NSObject, RSDTaskController {
             self.currentAsyncControllers.append(contentsOf: controllers)
             completion(controllers)
         }
+    }
+    
+    public func requestPermission(for controllers: [RSDAsyncAction], completion: @escaping (() -> Void)) {
+        requestPermissionsForAsyncActions_called = true
+        requestPermissionsForAsyncActions_calledWith = controllers
+        DispatchQueue.main.async {
+            for controller in controllers {
+                (controller as? TestAsyncActionController)?.requestPermission()
+            }
+            let set = NSMutableSet(array: self.currentAsyncControllers)
+            set.union(Set(controllers as! [TestAsyncActionController]))
+            self.currentAsyncControllers = set.allObjects as! [TestAsyncActionController]
+            completion()
+        }
+    }
+    
+    public func startAsyncActionsIfNeeded() {
+        assertionFailure("Not implemented")
     }
     
     public func startAsyncActions(for controllers: [RSDAsyncAction], showLoading: Bool, completion: @escaping (() -> Void)) {

--- a/Research/Research/RSDTaskController.swift
+++ b/Research/Research/RSDTaskController.swift
@@ -173,7 +173,7 @@ public protocol RSDTaskController : class, NSObjectProtocol {
     ///     - completion: The completion to call with the instantiated controllers.
     func addAsyncActions(with configurations: [RSDAsyncActionConfiguration], path: RSDPathComponent, completion: @escaping (([RSDAsyncAction]) -> Void))
     
-    /// Request permission for a controllers but do *not* start the controller.
+    /// Request permissions for controllers but do *not* start the controllers.
     ///
     /// - parameters:
     ///     - controllers: The controllers for which to request permissions.

--- a/Research/Research/RSDTaskController.swift
+++ b/Research/Research/RSDTaskController.swift
@@ -172,6 +172,16 @@ public protocol RSDTaskController : class, NSObjectProtocol {
     ///     - path: The path component that is currently being navigated.
     ///     - completion: The completion to call with the instantiated controllers.
     func addAsyncActions(with configurations: [RSDAsyncActionConfiguration], path: RSDPathComponent, completion: @escaping (([RSDAsyncAction]) -> Void))
+    
+    /// Request permission for a controllers but do *not* start the controller.
+    ///
+    /// - parameters:
+    ///     - controllers: The controllers for which to request permissions.
+    ///     - completion: The completion to call with the instantiated controllers.
+    func requestPermission(for controllers: [RSDAsyncAction], completion: @escaping (() -> Void))
+    
+    /// Start all async actions that are waiting to be started.
+    func startAsyncActionsIfNeeded()
 
     /// Start the async actions. The protocol extension calls this method when an async action should be
     /// started directly *after* the step is presented.

--- a/Research/Research/RSDTaskViewModel.swift
+++ b/Research/Research/RSDTaskViewModel.swift
@@ -826,7 +826,7 @@ extension RSDTaskViewModel {
         }
         
         // Notify the controllers that the task has moved to the given step and start the idle controllers.
-        excludedControllers.append(contentsOf: _startIdleAsyncControllers(excludingControllers: excludedControllers))
+        excludedControllers.append(contentsOf: _requestPermissionForIdleAsyncControllers(excludingControllers: excludedControllers))
         _notifyAsyncControllers(to: step, excludingControllers: excludedControllers)
         
         // Ready to save if this is the completion step and there isn't a back button.
@@ -857,13 +857,13 @@ extension RSDTaskViewModel {
         }
     }
     
-    private func _startIdleAsyncControllers(excludingControllers: [RSDAsyncAction]) -> [RSDAsyncAction] {
+    private func _requestPermissionForIdleAsyncControllers(excludingControllers: [RSDAsyncAction]) -> [RSDAsyncAction] {
         guard let taskController = self.taskController else { return [] }
         let controllers = taskController.currentAsyncControllers.filter { (lhs) -> Bool in
             return (lhs.status == .idle) && !excludingControllers.contains(where: { $0.isEqual(lhs) })
         }
         guard controllers.count > 0 else { return [] }
-        taskController.startAsyncActions(for: controllers, showLoading: false) {
+        taskController.requestPermission(for: controllers) {
             // Do nothing
         }
         return controllers

--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -989,6 +989,7 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
     open func start() {
         _startTimer()
         _setupInterruptionObserver()
+        self.taskController?.startAsyncActionsIfNeeded()
     }
     
     private func _startTimer() {


### PR DESCRIPTION
Change the logic for starting a recorder to trigger when the step *timer* starts rather than
just after transitioning to the step.