### PR TITLE
Add a timezone property to the scheduled time

### DIFF
--- a/Research/Research/RSDSchedule.swift
+++ b/Research/Research/RSDSchedule.swift
@@ -38,7 +38,7 @@ public protocol RSDScheduleTime {
     /// The time of the day as a string with the format "HH:mm:ss" or "HH:mm".
     var timeOfDayString: String? { get }
     
-    /// The time zone for the time of day.
+    /// The original time zone for the time of day.
     var timeZone: TimeZone { get }
 }
 

--- a/Research/Research/RSDSchedule.swift
+++ b/Research/Research/RSDSchedule.swift
@@ -37,6 +37,9 @@ public protocol RSDScheduleTime {
     
     /// The time of the day as a string with the format "HH:mm:ss" or "HH:mm".
     var timeOfDayString: String? { get }
+    
+    /// The time zone for the time of day.
+    var timeZone: TimeZone { get }
 }
 
 /// The `RSDSchedule` protocol can be used to describe a local notification schedule. This provides a
@@ -63,7 +66,8 @@ extension RSDScheduleTime {
     /// - parameter date: The date for which to set the time.
     public func timeOfDay(on date:Date) -> Date? {
         guard let timeComponents = self.timeComponents else { return nil }
-        let calendar = Calendar.iso8601
+        var calendar = Calendar.iso8601
+        calendar.timeZone = self.timeZone
         var components = calendar.dateComponents([.year, .month, .day], from: date)
         components.hour = timeComponents.hour
         components.minute = timeComponents.minute

--- a/Research/Research/RSDWeeklyScheduleObject.swift
+++ b/Research/Research/RSDWeeklyScheduleObject.swift
@@ -57,7 +57,7 @@ public struct RSDWeeklyScheduleObject : Codable, RSDSchedule {
     /// The time of the day as a string with the format "HH:mm".
     public var timeOfDayString: String?
     
-    /// Return the current time zone.b
+    /// Return the current time zone.
     public var timeZone: TimeZone {
         return TimeZone.current
     }

--- a/Research/Research/RSDWeeklyScheduleObject.swift
+++ b/Research/Research/RSDWeeklyScheduleObject.swift
@@ -57,6 +57,11 @@ public struct RSDWeeklyScheduleObject : Codable, RSDSchedule {
     /// The time of the day as a string with the format "HH:mm".
     public var timeOfDayString: String?
     
+    /// Return the current time zone.b
+    public var timeZone: TimeZone {
+        return TimeZone.current
+    }
+    
     /// Is this a daily scheduled item?
     public var isDaily: Bool {
         return self.daysOfWeek == RSDWeekday.all


### PR DESCRIPTION
Add using the timezone to get the time of day for a schedule

Requires: https://github.com/Sage-Bionetworks/BridgeApp-Apple-SDK/pull/144
This is a breaking change to BridgeApp because it includes a change to the protocol used by BridgeApp.