### PR TITLE
Make the taskRunUUID readonly

### DIFF
--- a/Research/Research/RSDTaskResult.swift
+++ b/Research/Research/RSDTaskResult.swift
@@ -39,7 +39,7 @@ import Foundation
 public protocol RSDTaskResult : RSDResult, RSDAnswerResultFinder {
     
     /// A unique identifier for this task run.
-    var taskRunUUID: UUID { get set }
+    var taskRunUUID: UUID { get }
     
     /// Schema info associated with this task.
     var schemaInfo: RSDSchemaInfo? { get set }
@@ -52,6 +52,14 @@ public protocol RSDTaskResult : RSDResult, RSDAnswerResultFinder {
     /// The step history is used to describe the path you took to get to where you are going, whereas
     /// the asynchronous results include any canonical results that are independent of path.
     var asyncResults: [RSDResult]? { get set }
+}
+
+/// The `RSDTaskRunResult` is a task result where the task run UUID can be set to allow for nested
+/// results that all use the same run UUID.
+public protocol RSDTaskRunResult : RSDTaskResult {
+    
+    /// A unique identifier for this task run.
+    var taskRunUUID: UUID { get set }
 }
 
 extension RSDTaskResult  {

--- a/Research/Research/RSDTaskResultObject.swift
+++ b/Research/Research/RSDTaskResultObject.swift
@@ -35,7 +35,7 @@ import Foundation
 
 /// `RSDTaskResultObject` is a result associated with a task. This object includes a step history, task run UUID,
 /// schema identifier, and asynchronous results.
-public struct RSDTaskResultObject : RSDTaskResult, Codable {
+public struct RSDTaskResultObject : RSDTaskRunResult, Codable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case identifier, type, startDate, endDate, taskRunUUID, schemaInfo, stepHistory, asyncResults
     }

--- a/Research/Research/RSDTaskViewModel.swift
+++ b/Research/Research/RSDTaskViewModel.swift
@@ -143,7 +143,9 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
         guard let parent = parentPath else { return }
         self.dataManager = (parent as? RSDHistoryPathComponent)?.dataManager
         self.previousResults = (parent.taskResult.stepHistory.last(where: { $0.identifier == identifier }) as? RSDTaskResult)?.stepHistory
-        self.taskResult.taskRunUUID = parent.taskResult.taskRunUUID
+        var runResult = self.taskResult as? RSDTaskRunResult
+        runResult?.taskRunUUID = parent.taskResult.taskRunUUID
+        self.taskResult = runResult ?? self.taskResult
         if let _ = self.task as? RSDSectionStep {
             self.shouldShowAbbreviatedInstructions = (parentPath as? RSDTaskViewModel)?.shouldShowAbbreviatedInstructions
         }
@@ -487,8 +489,9 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
                     results.append(contentsOf: previousResult.asyncResults!)
                     newResult.asyncResults = results
                 }
-                newResult.taskRunUUID = previousResult.taskRunUUID
-                strongSelf.taskResult = newResult
+                var runResult = newResult as? RSDTaskRunResult
+                runResult?.taskRunUUID = previousResult.taskRunUUID
+                strongSelf.taskResult = runResult ?? newResult
             }
             else {
                 err = error ?? RSDValidationError.unexpectedNullObject("Fetched a nil task without an associated error")


### PR DESCRIPTION
`ORKTaskResult` uses a readonly property to define the taskRunUUID because the tasks are not designed to support nesting. This allows supporting the `RSDTaskResult` protocol with an `ORKTaskPresult` as the backing object.