### PR TITLE
Use a cross-disolve to load the first image rather than setting the last image

### DIFF
--- a/Research/Research/RSDFileWrapper.swift
+++ b/Research/Research/RSDFileWrapper.swift
@@ -140,18 +140,16 @@ extension RSDFileWrapper {
     private func drawImage(from document:CGPDFDocument, at pageIndex: Int) -> UIImage? {
         guard let page = document.page(at: pageIndex) else { return nil }
         // TODO: syoung 08/01/2019 Look into rendering at the size requested by the view.
-        let pageRect = page.getBoxRect(.mediaBox)
+        let scale = UIScreen.main.scale
+        let pageRect = page.getBoxRect(.mediaBox).applying(.init(scaleX: scale, y: scale))
         let renderer = UIGraphicsImageRenderer(size: pageRect.size)
         let img = renderer.image { ctx in
             UIColor.clear.set()
             ctx.fill(pageRect)
-            
             ctx.cgContext.translateBy(x: 0.0, y: pageRect.size.height)
-            ctx.cgContext.scaleBy(x: 1.0, y: -1.0)
-            
+            ctx.cgContext.scaleBy(x: scale, y: -1.0 * scale)
             ctx.cgContext.drawPDFPage(page)
         }
-        
         return img
     }
     

--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -443,15 +443,15 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
             DispatchQueue.global().async { [weak navigationView] in
                 let images = animatedImage.images(compatibleWith: self.traitCollection)
                 DispatchQueue.main.async {
-                    guard let navigationView = navigationView, let image = images.last
+                    guard let navigationView = navigationView,
+                        let image = images.first
                         else {
                             return
                     }
                     UIView.transition(with: navigationView,
-                                      duration: 0.5,
+                                      duration: 0.2,
                                       options: .transitionCrossDissolve,
                                       animations: {
-                                        // Always set the last image as the one to show when/if the animation ends.
                                         navigationView.imageView?.image = image },
                                       completion: { (finished) in
                                         // If there is more than one image in the collection, then animate them.
@@ -462,6 +462,8 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
                                                 navigationView.imageView?.animationRepeatCount = repeatCount
                                             }
                                             navigationView.imageView?.startAnimating()
+                                            // Always set the last image as the one to show when/if the animation ends.
+                                            navigationView.imageView?.image = images.last
                                         }
                     })
                 }


### PR DESCRIPTION
Otherwise, it looks weird for non-looping images.