### PR TITLE
Add an example app delegate that handles orientation locking

### DIFF
--- a/RSDCatalog/RSDCatalog/Info.plist
+++ b/RSDCatalog/RSDCatalog/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>53</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/RSDCatalog/RSDCatalogTests/Info.plist
+++ b/RSDCatalog/RSDCatalogTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>53</string>
 </dict>

--- a/RSDCatalog/RSDCatalogUITests/Info.plist
+++ b/RSDCatalog/RSDCatalogUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>53</string>
 </dict>

--- a/Research/Research-UnitTest/Info.plist
+++ b/Research/Research-UnitTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research.xcodeproj/project.pbxproj
+++ b/Research/Research.xcodeproj/project.pbxproj
@@ -1025,6 +1025,7 @@
 		FF8B54EC1FCE6D15006B6937 /* RSDColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDFF5CE1FC3EE5C009713E8 /* RSDColor.swift */; };
 		FF8B54ED1FCE6D15006B6937 /* RSDExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF159DE1FB4D7A60061BA93 /* RSDExceptionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF8B54EE1FCE6D15006B6937 /* RSDExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FFF159DF1FB4D7A60061BA93 /* RSDExceptionHandler.m */; };
+		FF9557CC23060F4B00B8D60B /* RSDAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9557CB23060F4B00B8D60B /* RSDAppDelegate.swift */; };
 		FFABCB9422D9275600D11109 /* RSDCountdownUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFABCB9322D9275600D11109 /* RSDCountdownUIStepObject.swift */; };
 		FFABCB9522D9275600D11109 /* RSDCountdownUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFABCB9322D9275600D11109 /* RSDCountdownUIStepObject.swift */; };
 		FFABCB9622D9275600D11109 /* RSDCountdownUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFABCB9322D9275600D11109 /* RSDCountdownUIStepObject.swift */; };
@@ -1403,6 +1404,7 @@
 		FF8E5F3E1F8C258200611C23 /* RSDSectionStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDSectionStepObject.swift; sourceTree = "<group>"; };
 		FF8E5F441F8C36F400611C23 /* RSDTaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTaskViewModel.swift; sourceTree = "<group>"; };
 		FF8E5F461F8C3DA000611C23 /* RSDAsyncAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDAsyncAction.swift; sourceTree = "<group>"; };
+		FF9557CB23060F4B00B8D60B /* RSDAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDAppDelegate.swift; sourceTree = "<group>"; };
 		FF9D7F661FA8E0FE008506DB /* RSDViewThemeElementObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDViewThemeElementObject.swift; sourceTree = "<group>"; };
 		FFA973321FBE454F00AA7317 /* TaskControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskControllerTests.swift; sourceTree = "<group>"; };
 		FFABCB9322D9275600D11109 /* RSDCountdownUIStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDCountdownUIStepObject.swift; sourceTree = "<group>"; };
@@ -1761,6 +1763,7 @@
 		F84496022273A23100EAA3E0 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				FF9557CB23060F4B00B8D60B /* RSDAppDelegate.swift */,
 				F84496032273A23100EAA3E0 /* RSDTaskViewController.swift */,
 				F844961F2273A23100EAA3E0 /* RSDStepViewController.swift */,
 				F84496082273A23100EAA3E0 /* Step View Controllers */,
@@ -3161,6 +3164,7 @@
 				F84496472273A23100EAA3E0 /* DebugStepViewController.swift in Sources */,
 				F84496482273A23100EAA3E0 /* RSDCountdownStepViewController.swift in Sources */,
 				F84496402273A23100EAA3E0 /* RSDWebViewController.swift in Sources */,
+				FF9557CC23060F4B00B8D60B /* RSDAppDelegate.swift in Sources */,
 				F844966B2273A23100EAA3E0 /* RSDBackgroundGradient.swift in Sources */,
 				F84496572273A23100EAA3E0 /* RSDStepViewController.swift in Sources */,
 				F844965C2273A23100EAA3E0 /* RSDUISoundPlayer.swift in Sources */,

--- a/Research/Research/Info-iOS.plist
+++ b/Research/Research/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-macOS.plist
+++ b/Research/Research/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Research/Research/Info-tvOS.plist
+++ b/Research/Research/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-watchOS.plist
+++ b/Research/Research/Info-watchOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 	<key>NSPrincipalClass</key>

--- a/Research/ResearchLocation/Info.plist
+++ b/Research/ResearchLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 </dict>

--- a/Research/ResearchLocationTests/Info.plist
+++ b/Research/ResearchLocationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 </dict>

--- a/Research/ResearchMotion/Info.plist
+++ b/Research/ResearchMotion/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 </dict>

--- a/Research/ResearchMotionTests/Info.plist
+++ b/Research/ResearchMotionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 </dict>

--- a/Research/ResearchRecorders/Info-iOS.plist
+++ b/Research/ResearchRecorders/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 </dict>

--- a/Research/ResearchTests/Info-iOS.plist
+++ b/Research/ResearchTests/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 </dict>

--- a/Research/ResearchUI/Info-iOS.plist
+++ b/Research/ResearchUI/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 </dict>

--- a/Research/ResearchUI/iOS/RSDAppDelegate.swift
+++ b/Research/ResearchUI/iOS/RSDAppDelegate.swift
@@ -112,7 +112,7 @@ open class RSDAppDelegate : UIResponder, RSDAppOrientationLock, RSDAlertPresente
 /// As of this writing, there is no simple way for an application to allow selectively locking
 /// the orientation of the app to portrait, while still allowing *some* view controllers to
 /// require landscape. This is intended as a work-around for that limitation. Using this feature
-/// requires that the view controller that needs to change the orientation to set the
+/// requires the view controller that needs to change the orientation to set the
 /// `orientationLock` in `viewWillAppear` and then clear the lock on `viewDidAppear`.
 /// syoung 08/15/2019
 ///

--- a/Research/ResearchUI/iOS/RSDAppDelegate.swift
+++ b/Research/ResearchUI/iOS/RSDAppDelegate.swift
@@ -1,0 +1,143 @@
+//
+//  RSDAppDelegate.swift
+//  ResearchUI (iOS)
+//
+//  Copyright © 2019 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `RSDAppDelegate` is an optional class that can be used as the appDelegate for an application.
+///
+/// Using this class as the base class of your app delegate is not required, but is included as a
+/// possible solution to certain common issues with setting up an app.
+open class RSDAppDelegate : UIResponder, RSDAppOrientationLock, RSDAlertPresenter  {
+    
+    open var window: UIWindow?
+    
+    /// Override to set the shared factory on startup.
+    open func instantiateFactory() -> RSDFactory {
+        return RSDFactory()
+    }
+    
+    /// Override and return a non-nil value to set up using a custom color palette with your app.
+    open func instantiateColorPalette() -> RSDColorPalette? {
+        return nil
+    }
+    
+    open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization before application launch.
+        
+        // Set up color palette and factory.
+        RSDFactory.shared = instantiateFactory()
+        if let palette = instantiateColorPalette() {
+            RSDStudyConfiguration.shared.colorPalette = palette
+        }
+        
+        // Set the tint color.
+        self.window?.tintColor = RSDStudyConfiguration.shared.colorPalette.primary.normal.color
+        
+        return true
+    }
+    
+    
+    // ------------------------------------------------
+    // MARK: RSDAlertPresenter
+    // ------------------------------------------------
+    
+    /// Convenience method for presenting a modal view controller.
+    open func presentModal(_ viewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        guard let rootVC = self.window?.rootViewController else { return }
+        var topViewController: UIViewController = rootVC
+        while let presentedVC = topViewController.presentedViewController {
+            if presentedVC.modalPresentationStyle != .fullScreen {
+                presentedVC.dismiss(animated: false, completion: nil)
+                break
+            }
+            else {
+                topViewController = presentedVC
+            }
+        }
+        topViewController.present(viewController, animated: animated, completion: completion)
+    }
+    
+    
+    // ------------------------------------------------
+    // MARK: Lock orientation to portrait by default
+    // ------------------------------------------------
+    
+    /// The default orientation lock if not overridden by setting the `orientationLock` property.
+    ///
+    /// An application that requires the *default* to be either portrait or landscape, while still
+    /// setting the app allowed orientations to allow some view controllers to rotate must override
+    /// this property to return those orientations only.
+    ///
+    open var defaultOrientationLock: UIInterfaceOrientationMask {
+        return .all
+    }
+    
+    /// The `orientationLock` property is used to override the default allowed orientations.
+    ///
+    /// - seealso: `defaultOrientationLock`
+    open var orientationLock: UIInterfaceOrientationMask?
+    
+}
+
+/// As of this writing, there is no simple way for an application to allow selectively locking
+/// the orientation of the app to portrait, while still allowing *some* view controllers to
+/// require landscape. This is intended as a work-around for that limitation. Using this feature
+/// requires that the view controller that needs to change the orientation to set the
+/// `orientationLock` in `viewWillAppear` and then clear the lock on `viewDidAppear`.
+/// syoung 08/15/2019
+///
+/// - seealso: `RSDAppDelegate` for an example implementation.
+public protocol RSDAppOrientationLock : UIApplicationDelegate {
+    
+    /// The default orientation lock if not overridden by setting the `orientationLock` property.
+    var defaultOrientationLock: UIInterfaceOrientationMask { get }
+    
+    /// The `orientationLock` property is used to override the default allowed orientations.
+    ///
+    /// - seealso: `defaultOrientationLock`
+    var orientationLock: UIInterfaceOrientationMask? { get set }
+}
+
+extension RSDAppOrientationLock {
+    
+    /// Convenience accessor for the appLock for applications where the app delegate implements
+    /// this protocol.
+    public static var appLock: RSDAppOrientationLock? {
+        return UIApplication.shared.delegate as? RSDAppOrientationLock
+    }
+
+    /// - returns: The `orientationLock` or the `defaultOrientationLock` if nil.
+    public func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return orientationLock ?? defaultOrientationLock
+    }
+}

--- a/Research/ResearchUITests/Info.plist
+++ b/Research/ResearchUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
 	<string>60</string>
 </dict>


### PR DESCRIPTION
This is moved into this framework as a convenience for applications that need to conditionally support locking the device orientation to either portrait or landscape.

This came up in the Mobile Toolbox team's discussion of attempting to set up tests for their frameworks that do not require being tied to Bridge services. This is the only feature in BridgeApp that is required for many of their instruments.