### PR TITLE
Support filling in the previous survey answers

### DIFF
--- a/Research/Research/RSDChoicePickerTableItemGroup.swift
+++ b/Research/Research/RSDChoicePickerTableItemGroup.swift
@@ -82,10 +82,22 @@ open class RSDChoicePickerTableItemGroup : RSDInputFieldTableItemGroup {
         super.init(beginningRowIndex: beginningRowIndex, items: items!, inputField: inputField, uiHint: uiHint, answerType: aType)
     }
     
-    // Override to set the selected items from the result.
+    /// Override to set the selected items.
+    override open func setPreviousAnswer(from jsonValue: Any?) throws {
+        try super.setPreviousAnswer(from: jsonValue)
+        let result = RSDAnswerResultObject(identifier: self.identifier,
+                                                 answerType: self.answerType,
+                                                 value: jsonValue)
+        self.updateSelected(from: result)
+    }
+    
+    /// Override to set the selected items from the result.
     override open func setAnswer(from result: RSDResult) throws {
         try super.setAnswer(from: result)
+        self.updateSelected(from: result)
+    }
         
+    private func updateSelected(from result: RSDResult) {
         // Set all the previously selected items as selected
         guard let selectableItems = self.items as? [RSDChoiceTableItem] else { return }
         for input in selectableItems {

--- a/Research/Research/RSDDataStorageManager.swift
+++ b/Research/Research/RSDDataStorageManager.swift
@@ -54,5 +54,8 @@ public protocol RSDSwiftDataStorageManager : class, NSObjectProtocol {
 }
 
 @objc public protocol RSDObjCDataStorageManager : class, NSObjectProtocol {
-    // Placeholder for future optional protocol methods.
+    
+    /// Optional. Should survey questions be shown in subsequent runs using the results from a
+    /// previous run?
+    @objc optional func shouldUsePreviousAnswers(for taskIdentifier: String) -> Bool
 }

--- a/Research/Research/RSDInputFieldTableItemGroup.swift
+++ b/Research/Research/RSDInputFieldTableItemGroup.swift
@@ -105,6 +105,11 @@ open class RSDInputFieldTableItemGroup : RSDTableItemGroup {
         try textItem.setAnswer(newValue)
     }
     
+    /// Set the answer from a previous run to the given value.
+    open func setPreviousAnswer(from jsonValue: Any?) throws {
+        try setAnswer(jsonValue)
+    }
+    
     /// Set the default answer for the item group. The base class implementation does nothing.
     /// - returns: `true` if the answer was updated and `false` if the answer was unchanged.
     open func setDefaultAnswerIfValid() -> Bool {

--- a/Research/Research/RSDPathComponent.swift
+++ b/Research/Research/RSDPathComponent.swift
@@ -118,6 +118,9 @@ public protocol RSDHistoryPathComponent : RSDPathComponent {
     
     /// Get the previous result for the given step.
     func previousResult(for step: RSDStep) -> RSDResult?
+    
+    /// The previous data for this task.
+    var previousTaskData: RSDTaskData? { get }
 }
 
 /// A task path component is a navigational path component that, depending upon the UI/UX, may not have an

--- a/Research/Research/RSDTaskViewModel.swift
+++ b/Research/Research/RSDTaskViewModel.swift
@@ -520,6 +520,9 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
         return self.task as? RSDTrackingTask
     }
     
+    /// The previous data queried during task set up from the data manager.
+    public private(set) var previousTaskData: RSDTaskData?
+    
     /// Called when the task is loaded and when the`dataManager` is set.
     open func setupDataTracking() {
         guard let task = self.task,
@@ -527,6 +530,7 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
             else {
                 return
         }
+        self.previousTaskData = taskData
         self.dataTracker?.setupTask(with: taskData, for: self)
         if shouldShowAbbreviatedInstructions == nil, let timestamp = taskData.timestampDate {
             let frequency = RSDStudyConfiguration.shared.fullInstructionsFrequency


### PR DESCRIPTION
Add method for populating the survey with the previous answers using the taskData rather than the task view model's previous results.