### PR TITLE
Add blanking out “sparsely populated” zip codes

### DIFF
--- a/Research/Research/RSDPostalCodeTableItem.swift
+++ b/Research/Research/RSDPostalCodeTableItem.swift
@@ -36,7 +36,22 @@ import Foundation
 open class RSDPostalCodeTableItem : RSDTextInputTableItem {
     
     /// The number of characters after which to replace the rest with "*" characters.
-    let characterCount = 3
+    public let characterCount = 3
+    
+    /// A list of known sparsely populated postal codes.
+    ///
+    /// Currently, the list of postal codes inclues the codes from the US 2010 census and is *only*
+    /// checked for US zipcodes.
+    public let sparselyPopulatedCodes: [String : [String]] =
+        ["US" : [036,059,102,203,205,369,556,692,821,823,878,879,884,893].map { "\($0)"}]
+    
+    /// The country code for the participant. By default, this will return the region code for the
+    /// participant's locale or "US" if the region code is unknown.
+    public var countryCode: String! {
+        get { return _countryCode ?? "US" }
+        set { _countryCode = newValue }
+    }
+    private var _countryCode: String? = Locale.current.regionCode
     
     public init(rowIndex: Int, inputField: RSDInputField) {
         
@@ -55,13 +70,26 @@ open class RSDPostalCodeTableItem : RSDTextInputTableItem {
     /// Override to replace the characters after the first 3 with "*".
     open override func convertAnswer(_ newValue: Any) throws -> Any? {
         guard let code = try super.convertAnswer(newValue) as? String else { return nil }
-        guard code.count > characterCount else { return code }
+        return deidentifyCode(code)
+    }
+    
+    func deidentifyCode(_ code: String) -> String {
+        guard code.count >= characterCount else { return code }
         
+        // Determine where to start replacing the characters with "*" characters.
+        var start = code.index(code.startIndex, offsetBy: characterCount)
+        var repeatCount = code.count - characterCount
+        let subcode = String(code[..<start])
+        if let codes = sparselyPopulatedCodes[countryCode], codes.contains(subcode) {
+            start = code.startIndex
+            repeatCount = code.count
+        }
+        
+        // Replace from `start`.
         var value = code
-        let start = value.index(value.startIndex, offsetBy: characterCount)
-        let replacement = String(repeating: "*", count: value.count - characterCount)
+        let replacement = String(repeating: "*", count: repeatCount)
         value.replaceSubrange(start..., with: replacement)
-
+        
         return value
     }
 }

--- a/Research/Research/RSDPostalCodeTableItem.swift
+++ b/Research/Research/RSDPostalCodeTableItem.swift
@@ -40,7 +40,7 @@ open class RSDPostalCodeTableItem : RSDTextInputTableItem {
     
     /// A list of known sparsely populated postal codes.
     ///
-    /// Currently, the list of postal codes inclues the codes from the US 2010 census and is *only*
+    /// Currently, the list of postal codes includes the codes from the US 2010 census and is *only*
     /// checked for US zipcodes.
     public let sparselyPopulatedCodes: [String : [String]] =
         ["US" : [036,059,102,203,205,369,556,692,821,823,878,879,884,893].map { "\($0)"}]

--- a/Research/ResearchTests/DataSource Tests/TableItemTests.swift
+++ b/Research/ResearchTests/DataSource Tests/TableItemTests.swift
@@ -340,4 +340,24 @@ class TableItemTests: XCTestCase {
             XCTFail("Threw unexpected error \(error)")
         }
     }
+    
+    func testPostalCode() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
+        
+        let inputField = RSDInputFieldObject(identifier: "postalCode", dataType: .postalCode)
+        let postalCodeItem = RSDPostalCodeTableItem(rowIndex: 0, inputField: inputField)
+        
+        do {
+            try postalCodeItem.setAnswer("98101")
+            let answerA = postalCodeItem.answer as? String
+            XCTAssertEqual(answerA, "981**")
+            
+            try postalCodeItem.setAnswer("89301")
+            let answerB = postalCodeItem.answer as? String
+            XCTAssertEqual(answerB, "*****")
+            
+        } catch let error {
+            XCTFail("Threw unexpected error \(error)")
+        }
+    }
 }


### PR DESCRIPTION
Note: This does not address the issue of a two-part question with handling for different region codes and is currently only implemented for US postal codes where the region is set to "US". But it's a start... ¯\\_(ツ)_/¯ 

Handling other countries and doing so gracefully requires more research and UI/UX design.