### PR TITLE
ME-110 Do not allow setting async recorder state to less than current

### DIFF
--- a/Research/Research/RSDAsyncAction.swift
+++ b/Research/Research/RSDAsyncAction.swift
@@ -104,6 +104,35 @@ extension RSDAsyncActionStatus : Comparable {
     }
 }
 
+extension RSDAsyncActionStatus : CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .idle:
+            return "idle"
+        case .requestingPermission:
+            return "requestingPermission"
+        case .permissionGranted:
+            return "permissionGranted"
+        case .starting:
+            return "starting"
+        case .running:
+            return "running"
+        case .waitingToStop:
+            return "waitingToStop"
+        case .processingResults:
+            return "processingResults"
+        case .stopping:
+            return "stopping"
+        case .finished:
+            return "finished"
+        case .cancelled:
+            return "cancelled"
+        case .failed:
+            return "failed"
+        }
+    }
+}
+
 /// The completion handler for starting and stopping an async action.
 public typealias RSDAsyncActionCompletionHandler = (RSDAsyncAction, RSDResult?, Error?) -> Void
 

--- a/Research/ResearchMotion/RSDMotionRecorder.swift
+++ b/Research/ResearchMotion/RSDMotionRecorder.swift
@@ -126,9 +126,10 @@ public class RSDMotionRecorder : RSDSampleRecorder {
     
     /// Override to implement requesting permission to access the participant's motion sensors.
     override public func requestPermissions(on viewController: UIViewController, _ completion: @escaping RSDAsyncActionCompletionHandler) {
+        self.updateStatus(to: .requestingPermission , error: nil)
         if RSDMotionAuthorization.authorizationStatus() == .authorized {
             self.updateStatus(to: .permissionGranted , error: nil)
-            completion(self, nil, error)
+            completion(self, nil, nil)
         } else {
             RSDMotionAuthorization.requestAuthorization { [weak self] (authStatus, error) in
                 guard let strongSelf = self else { return }

--- a/Research/ResearchUI/iOS/RSDTaskViewController.swift
+++ b/Research/ResearchUI/iOS/RSDTaskViewController.swift
@@ -618,6 +618,9 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
                             if let asyncResult = result {
                                 controller.taskViewModel.taskResult.appendAsyncResult(with: asyncResult)
                             }
+                            else if error == nil {
+                                print("WARNING! NULL result for async action \(controller.configuration.identifier)")
+                            }
                             if error != nil {
                                 self?._addErrorResult(for: controller, error: error!)
                             }
@@ -785,10 +788,27 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
     
     class InflightController {
         let controller: RSDAsyncAction
-        var requestedState: RSDAsyncActionStatus
+        private let stateQueue = DispatchQueue(label: "org.sagebase.Research.InflightState.\(UUID())")
+        var requestedState: RSDAsyncActionStatus {
+            get {
+                var ret: RSDAsyncActionStatus!
+                stateQueue.sync {
+                    ret = self._requestedState
+                }
+                return ret
+            }
+            set {
+                stateQueue.sync {
+                    if newValue > _requestedState {
+                        self._requestedState = newValue
+                    }
+                }
+            }
+        }
+        private var _requestedState: RSDAsyncActionStatus
         init(controller: RSDAsyncAction, requestedState: RSDAsyncActionStatus) {
             self.controller = controller
-            self.requestedState = requestedState
+            self._requestedState = requestedState
         }
     }
     
@@ -827,7 +847,7 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
             
             if error != nil {
                 // Add the error result if there was an error.
-                debugPrint("Failed to start recorder \(controller.configuration.identifier). status=\(controller.status) error=\(String(describing: error)) ")
+                print("WARNING! Failed to start recorder \(controller.configuration.identifier). status=\(controller.status) error=\(String(describing: error)) ")
                 self?._addErrorResult(for: controller, error: error!)
             }
             else if (controller.status == .finished), let asyncResult = result {

--- a/Research/ResearchUI/iOS/RSDTaskViewController.swift
+++ b/Research/ResearchUI/iOS/RSDTaskViewController.swift
@@ -798,8 +798,8 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
                 return ret
             }
             set {
-                stateQueue.sync {
-                    if newValue > _requestedState {
+                stateQueue.async {
+                    if newValue > self._requestedState {
                         self._requestedState = newValue
                     }
                 }


### PR DESCRIPTION
Because of the different threads used in starting and stopping async actions, and because there are various different timings for *when* a recorder is started/stopped, state handling can get confusing.

This change sets the motion recorder status to `requestingPermission` before checking the current permission state. Additionally, it only allows setting the requested permission (handled by the task controller) in a forward direction. (Will not set to “requestPermission” if already “starting”)