### PR TITLE
Fix bug in setting the current text on text fields

### DIFF
--- a/Research/ResearchUI/iOS/Step View Controllers/RSDTableStepViewController.swift
+++ b/Research/ResearchUI/iOS/Step View Controllers/RSDTableStepViewController.swift
@@ -957,12 +957,7 @@ open class RSDTableStepViewController: RSDStepViewController, UITableViewDataSou
             }
         }()
         
-        // If this is a custom text field then update the text to match the
-        // actual value stored in case it differs from the text entered.
         let success = saveAnswer(newValue: answer ?? NSNull(), at: indexPath)
-        if !success, let tableItem = tableItem(for: textInputView) {
-            textInputView.currentText = tableItem.answerText
-        }
         return success
     }
     

--- a/Research/ResearchUI/iOS/Views/RSDStepTextFieldCell.swift
+++ b/Research/ResearchUI/iOS/Views/RSDStepTextFieldCell.swift
@@ -373,7 +373,7 @@ open class RSDStepTextField: UITextField, RSDStepTextInputView {
             return self.text
         }
         set {
-            self.text = currentText
+            self.text = newValue
         }
     }
     public var indexPath: IndexPath?
@@ -386,7 +386,7 @@ open class RSDStepTextView: UITextView, RSDStepTextInputView {
             return self.text
         }
         set {
-            self.text = currentText
+            self.text = newValue
         }
     }
     public var indexPath: IndexPath?


### PR DESCRIPTION
I also removed the code that sets this if the answer failed on the assumption that the current text should *not* change your answer out from under you and the only reason this wasn’t showing up as a UX bug was b/c it wasn’t working.