### PR TITLE
Set default presentation style to full screen modal

### DIFF
--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -107,6 +107,7 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
     public init(step: RSDStep, parent: RSDPathComponent?) {
         super.init(nibName: nil, bundle: nil)
         self.stepViewModel = self.instantiateStepViewModel(for: step, with: parent)
+        self.modalPresentationStyle = .fullScreen
     }
     
     /// Initialize the class using the given nib and bundle.
@@ -115,12 +116,14 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
     ///     - nibBundleOrNil: The name of the bundle or `nil`.
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        self.modalPresentationStyle = .fullScreen
     }
     
     /// Required initializer. This is the initializer used by a `UIStoryboard`.
     /// - parameter aDecoder: The decoder used to initialize this view controller.
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        self.modalPresentationStyle = .fullScreen
     }
     
     // MARK: View appearance handling

--- a/Research/ResearchUI/iOS/RSDTaskViewController.swift
+++ b/Research/ResearchUI/iOS/RSDTaskViewController.swift
@@ -138,12 +138,14 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
     ///     - nibBundleOrNil: The name of the bundle or `nil`.
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        self.modalPresentationStyle = .fullScreen
     }
     
     /// Initializer for initializing from a storyboard or restoring from shutdown by the OS.
     /// - parameter aDecoder: The decoder used to create the view controller.
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        self.modalPresentationStyle = .fullScreen
     }
     
     /// Initializer for initializing a view controller that is not associated with a storyboard or nib.
@@ -152,6 +154,7 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
         super.init(nibName: nil, bundle: nil)
         self.task = task
         self.taskViewModel.taskController = self
+        self.modalPresentationStyle = .fullScreen
     }
     
     /// Initializer for initializing a view controller that is not associated with a storyboard or nib.
@@ -160,6 +163,7 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
         super.init(nibName: nil, bundle: nil)
         self.taskInfo = taskInfo
         self.taskViewModel.taskController = self
+        self.modalPresentationStyle = .fullScreen
     }
     
     /// Initializer for initializing a view controller that is not associated with a storyboard or nib.
@@ -168,6 +172,7 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
         super.init(nibName: nil, bundle: nil)
         self.taskViewModel = taskViewModel
         self.taskViewModel.taskController = self
+        self.modalPresentationStyle = .fullScreen
     }
     
     // MARK: View controller vending


### PR DESCRIPTION
This is for an iOS 13 issue where a swipe down gesture can be used to dismiss a view controller. Setting to fulllscreen modal will remove that gesture recognizer. This is done during initialization so that it can be set by the presenting view controller to something else if the UI/UX calls for doing so.

@dephillipsmichael Does this solve the issue you discovered? Unfortunately, I don't have a phone that is on iOS 13. (Discovered with my iPad that older devices have a severe performance hit with iOS 13)