### PR TITLE
Add optional spoken warning when an activity is paused

### DIFF
--- a/RSDCatalog/RSDCatalog/Info.plist
+++ b/RSDCatalog/RSDCatalog/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>61</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/RSDCatalog/RSDCatalog/JSON Files/Recorder_Motion.json
+++ b/RSDCatalog/RSDCatalog/JSON Files/Recorder_Motion.json
@@ -33,7 +33,8 @@
                                                },
                                                {
                                                "identifier"     : "countdown",
-                                               "type"           : "countdown"
+                                               "type"           : "countdown",
+                                               "commands"       : ["speakWarningOnPause"]
                                                },
                                                {
                                                "identifier"         : "motion",

--- a/RSDCatalog/RSDCatalogTests/Info.plist
+++ b/RSDCatalog/RSDCatalogTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>61</string>
 </dict>

--- a/RSDCatalog/RSDCatalogUITests/Info.plist
+++ b/RSDCatalog/RSDCatalogUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>61</string>
 </dict>

--- a/Research/Research-UnitTest/Info.plist
+++ b/Research/Research-UnitTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-iOS.plist
+++ b/Research/Research/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-macOS.plist
+++ b/Research/Research/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Research/Research/Info-tvOS.plist
+++ b/Research/Research/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-watchOS.plist
+++ b/Research/Research/Info-watchOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/RSDActiveUIStepCommand.swift
+++ b/Research/Research/RSDActiveUIStepCommand.swift
@@ -93,6 +93,7 @@ public struct RSDActiveUIStepCommand : RSDStringLiteralOptionSet {
     ///     `continueOnFinish`
     ///     `transitionAutomatically`
     ///     `shouldDisableIdleTimer`
+    ///     `speakWarningOnPause`
     ///
     public private(set) static var stringMapping: [String : Int] = [:]
     
@@ -135,6 +136,9 @@ public struct RSDActiveUIStepCommand : RSDStringLiteralOptionSet {
     /// Disable the idle timer if included.
     public static let shouldDisableIdleTimer = RSDActiveUIStepCommand(1 << 6, codingKey: "shouldDisableIdleTimer")
     
+    /// Speak a warning when the pause button is tapped.
+    public static let speakWarningOnPause = RSDActiveUIStepCommand(1 << 7, codingKey: "speakWarningOnPause")
+
     /// The default commands for a step.
     public static let defaultCommands: RSDActiveUIStepCommand = []
 }
@@ -146,7 +150,8 @@ extension RSDActiveUIStepCommand : RSDDocumentableOptionSet {
         let _: RSDActiveUIStepCommand = [.playSound,
                                          .vibrate,
                                          .transitionAutomatically,
-                                         .shouldDisableIdleTimer]
+                                         .shouldDisableIdleTimer,
+                                         .speakWarningOnPause]
         return self.stringMapping.map{ $0.key }
     }
 }

--- a/Research/Research/en.lproj/Research.strings
+++ b/Research/Research/en.lproj/Research.strings
@@ -68,6 +68,7 @@
 "CURRENT_STEP_%@_OF_TOTAL_STEPS_%@" = "Step %1$@ of %2$@";  // Text for marking the current steps
 "MESSAGE_CONFIRM_CANCEL_TASK" = "Are you sure that you want to stop?";  // Message to show when confirming that tapping the close task button was intentional.
 "OVERVIEW_WHAT_YOU_NEED" = "This is what you'll need"; // Text on the overview scroll view for title of list of what you need for the task.
+"STEP_PAUSED" = "The activity has been paused.";
 
 /* Default placeholders to request answers in a questionnaire. */
 "PLACEHOLDER_TEXT_OR_NUMBER" = "Tap to answer";

--- a/Research/ResearchLocation/Info.plist
+++ b/Research/ResearchLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 </dict>

--- a/Research/ResearchLocationTests/Info.plist
+++ b/Research/ResearchLocationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 </dict>

--- a/Research/ResearchMotion/Info.plist
+++ b/Research/ResearchMotion/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 </dict>

--- a/Research/ResearchMotionTests/Info.plist
+++ b/Research/ResearchMotionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 </dict>

--- a/Research/ResearchRecorders/Info-iOS.plist
+++ b/Research/ResearchRecorders/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 </dict>

--- a/Research/ResearchTests/Info-iOS.plist
+++ b/Research/ResearchTests/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 </dict>

--- a/Research/ResearchUI/Info-iOS.plist
+++ b/Research/ResearchUI/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 </dict>

--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -1056,6 +1056,13 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
     open func pause() {
         clock?.pause()
         _stopTimer()
+        // If this is an active task that requests a spoken warning when the pause
+        // button is tapped, then do so.
+        if let commands = self.activeStep?.commands,
+            commands.contains(.speakWarningOnPause) {
+            let instruction = Localization.localizedString("STEP_PAUSED")
+            RSDSpeechSynthesizer.shared.speak(text: instruction, completion: nil)
+        }
     }
     
     /// Resume the timer.

--- a/Research/ResearchUITests/Info.plist
+++ b/Research/ResearchUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4</string>
+	<string>2.5</string>
 	<key>CFBundleVersion</key>
 	<string>68</string>
 </dict>


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/MP2-140

Note: This will only add the spoken instruction for steps that explicitly request doing so. I thought that while this is a useful tool for a task like the walk and balance, it could be jarring for other tasks.