### PR TITLE
Fix data source issues

### DIFF
--- a/Research/Research/RSDChoiceInputFieldObject.swift
+++ b/Research/Research/RSDChoiceInputFieldObject.swift
@@ -37,7 +37,7 @@ import Foundation
 /// `RSDInputFieldObject` to include a list of choices for a multiple choice or single choice input field. It
 /// is intended to be instantiated with a list of choices but can be subclassed to decode the choices using
 /// a custom decoder.
-open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
+open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptionsWithDefault {
     
     /// A list of choices for the input field.
     public private(set) var choices : [RSDChoice]
@@ -67,7 +67,7 @@ open class RSDChoiceInputFieldObject : RSDInputFieldObject, RSDChoiceOptions {
     ///               this field.
     public init(identifier: String, choices: [RSDChoice], dataType: RSDFormDataType, uiHint: RSDFormUIHint? = nil, prompt: String? = nil, defaultAnswer: Any? = nil) {
         self.choices = choices
-        self.defaultAnswer = nil
+        self.defaultAnswer = defaultAnswer
         super.init(identifier: identifier, dataType: dataType, uiHint: uiHint, prompt: prompt)
     }
     

--- a/Research/Research/RSDChoicePickerTableItemGroup.swift
+++ b/Research/Research/RSDChoicePickerTableItemGroup.swift
@@ -105,6 +105,32 @@ open class RSDChoicePickerTableItemGroup : RSDInputFieldTableItemGroup {
         }
     }
     
+    open override func setDefaultAnswerIfValid() -> Bool {
+        guard let selectableItems = self.items as? [RSDChoiceTableItem] else {
+            return super.setDefaultAnswerIfValid()
+        }
+        
+        // Do not select an answer if one is already set or there is no default.
+        guard !selectableItems.reduce(false, { $0 || $1.selected }),
+            let inputField = self.inputField as? RSDChoiceOptionsWithDefault,
+            let defaultAnswer = inputField.defaultAnswer
+            else {
+                return false
+        }
+        
+        do {
+            let result = RSDAnswerResultObject(identifier: self.identifier,
+                                                     answerType: self.answerType,
+                                                     value: defaultAnswer)
+            try self.setAnswer(from: result)
+            return true
+        }
+        catch let err {
+            assertionFailure("Failed to set the answer to the default. \(err)")
+            return false
+        }
+    }
+    
     /// Since the answer can be both `nil` *and* selected, override to check for selection state.
     open override var isAnswerValid: Bool {
         guard let selectableItems = self.items as? [RSDChoiceTableItem] else {

--- a/Research/Research/RSDChoicePickerTableItemGroup.swift
+++ b/Research/Research/RSDChoicePickerTableItemGroup.swift
@@ -105,6 +105,14 @@ open class RSDChoicePickerTableItemGroup : RSDInputFieldTableItemGroup {
         }
     }
     
+    /// Since the answer can be both `nil` *and* selected, override to check for selection state.
+    open override var isAnswerValid: Bool {
+        guard let selectableItems = self.items as? [RSDChoiceTableItem] else {
+            return super.isAnswerValid
+        }
+        return self.isOptional || selectableItems.reduce(false, { $0 || $1.selected })
+    }
+    
     /// Select or de-select an item (answer) at a specific indexPath. This is used for text choice and boolean
     /// answers.
     /// - parameters:

--- a/Research/Research/RSDDurationFormatter.m
+++ b/Research/Research/RSDDurationFormatter.m
@@ -113,7 +113,7 @@
     // syoung 10/17/2019 There appears to be a change with iOS 13 that this formatter
     // no longer conforms to the documentation for US English to read "1:30" versus "01:30".
     // In considering the "proper" behavior for this formatter, the formatting should respect
-    // the zero padding everywhere if the `zeroFormattingBehavior` including padding.
+    // the zero padding everywhere if the `zeroFormattingBehavior` includes padding.
     // However, older versions of the OS do *not* format with the 0 padding so check for this
     // and correct it so that our unit tests will work regardless of the target iOS version.
     BOOL isZeroPadded = ((self.zeroFormattingBehavior & NSDateComponentsFormatterZeroFormattingBehaviorPad) != 0);

--- a/Research/Research/RSDInputFieldTableItemGroup.swift
+++ b/Research/Research/RSDInputFieldTableItemGroup.swift
@@ -159,10 +159,14 @@ open class RSDInputFieldTableItemGroup : RSDTableItemGroup {
     /// - returns: A `Bool` indicating if answer is valid.
     open override var isAnswerValid: Bool {
         // if answer is NOT optional and it equals Null, then it's invalid
-        let isOptional = self.items.reduce(self.inputField.isOptional) {
+        return self.isOptional || !((self.answer == nil) || (self.answer is NSNull))
+    }
+    
+    /// Whether or not the question is optional.
+    open var isOptional: Bool {
+        return self.items.reduce(self.inputField.isOptional) {
             $0 && (($1 as? RSDInputFieldTableItem)?.inputField.isOptional ?? true)
         }
-        return isOptional || !((self.answer == nil) || (self.answer is NSNull))
     }
 }
 

--- a/Research/Research/RSDPickerDataSource.swift
+++ b/Research/Research/RSDPickerDataSource.swift
@@ -206,6 +206,13 @@ public protocol RSDChoiceOptions : RSDChoicePickerDataSource {
     var isOptional: Bool { get }
 }
 
+/// Extend the choice options protocol to allow setting a default value.
+public protocol RSDChoiceOptionsWithDefault : RSDChoiceOptions {
+    
+    /// The default answer (if any) to set for this choice options set.
+    var defaultAnswer: Any? { get }
+}
+
 extension RSDChoiceOptions {
     
     /// Convenience property for whether or not the choice input field has associated images.

--- a/Research/ResearchTests/DataSource Tests/FormStepTableDataSourceTests.swift
+++ b/Research/ResearchTests/DataSource Tests/FormStepTableDataSourceTests.swift
@@ -295,6 +295,39 @@ class FormStepTableDataSourceTests: XCTestCase {
         XCTAssertEqual(aResult.value as? Int, 0)
     }
     
+    func testBuildSections_SingleChoiceWithNil_DefaultValue() {
+        let choices = [try! RSDChoiceObject<Int>(value: 0, text: "one"),
+                       try! RSDChoiceObject<Int>(value: 1, text: "two"),
+                       try! RSDChoiceObject<Int>(value: 2, text: "three"),
+                       try! RSDChoiceObject<Int>(value: nil, text: "none")]
+        let inputField = RSDChoiceInputFieldObject(identifier: "foo", choices: choices, dataType: .collection(.singleChoice, .integer),uiHint: nil, prompt: nil, defaultAnswer: 0)
+        inputField.isOptional = false
+        let formStep = RSDFormUIStepObject(identifier: "foo", inputFields: [inputField])
+        let dataSource = RSDFormStepDataSourceObject(step: formStep, parent: nil)
+        
+        XCTAssertEqual(dataSource.itemGroups.count, 1)
+        guard let itemGroup = dataSource.itemGroups.first as? RSDChoicePickerTableItemGroup,
+            let tableItem = itemGroup.items.first as? RSDChoiceTableItem
+            else {
+                XCTFail("Failed to create expected type. \(dataSource.itemGroups)")
+                return
+        }
+        
+        // Before selecting an answer because there is a default answer that has been set,
+        // it should be valid.
+        XCTAssertTrue(dataSource.allAnswersValid())
+        XCTAssertTrue(tableItem.selected)
+        
+        guard let aResult = dataSource.collectionResult().inputResults.first as? RSDAnswerResult
+            else {
+                XCTFail("Failed to add answer result")
+                return
+        }
+        
+        // But the answer result should use a nil value.
+        XCTAssertEqual(aResult.value as? Int, 0)
+    }
+    
     // Helper methods
     
     func createDataSource(for json: Data, with initialResult: RSDCollectionResult? = nil) -> RSDFormStepDataSourceObject? {

--- a/Research/ResearchTests/DataSource Tests/FormStepTableDataSourceTests.swift
+++ b/Research/ResearchTests/DataSource Tests/FormStepTableDataSourceTests.swift
@@ -211,6 +211,90 @@ class FormStepTableDataSourceTests: XCTestCase {
         XCTAssertNil(dataSource.nextItem(after: IndexPath(row: 3, section: 1)))
     }
     
+    func testSelection_SingleChoiceWithNil() {
+        let choices = [try! RSDChoiceObject<Int>(value: 0, text: "one"),
+                       try! RSDChoiceObject<Int>(value: 1, text: "two"),
+                       try! RSDChoiceObject<Int>(value: 2, text: "three"),
+                       try! RSDChoiceObject<Int>(value: nil, text: "none")]
+        let inputField = RSDChoiceInputFieldObject(identifier: "foo", choices: choices, dataType: .collection(.singleChoice, .integer))
+        inputField.isOptional = false
+        let formStep = RSDFormUIStepObject(identifier: "foo", inputFields: [inputField])
+        let dataSource = RSDFormStepDataSourceObject(step: formStep, parent: nil)
+        
+        XCTAssertEqual(dataSource.itemGroups.count, 1)
+        guard let itemGroup = dataSource.itemGroups.first as? RSDChoicePickerTableItemGroup,
+            let tableItem = itemGroup.items.last
+            else {
+                XCTFail("Failed to create expected type. \(dataSource.itemGroups)")
+                return
+        }
+        
+        // Before selecting an answer because the input field is *not* optional, the answer is
+        // not valid.
+        XCTAssertFalse(dataSource.allAnswersValid())
+                
+        do {
+            let _ = try dataSource.selectAnswer(item: tableItem, at: IndexPath(row: 3, section: 0))
+        } catch let err {
+            XCTFail("Failed to select item group. \(err)")
+        }
+        
+        // After an answer has been selected, then the result is valid. This should be true even
+        // if the answer result value is nil.
+        XCTAssertTrue(dataSource.allAnswersValid())
+        
+        guard let aResult = dataSource.collectionResult().inputResults.first as? RSDAnswerResult
+            else {
+                XCTFail("Failed to add answer result")
+                return
+        }
+        
+        // But the answer result should use a nil value.
+        XCTAssertNil(aResult.value)
+    }
+    
+    func testSelection_SingleChoiceWithValueSelected() {
+        let choices = [try! RSDChoiceObject<Int>(value: 0, text: "one"),
+                       try! RSDChoiceObject<Int>(value: 1, text: "two"),
+                       try! RSDChoiceObject<Int>(value: 2, text: "three"),
+                       try! RSDChoiceObject<Int>(value: nil, text: "none")]
+        let inputField = RSDChoiceInputFieldObject(identifier: "foo", choices: choices, dataType: .collection(.singleChoice, .integer))
+        inputField.isOptional = false
+        let formStep = RSDFormUIStepObject(identifier: "foo", inputFields: [inputField])
+        let dataSource = RSDFormStepDataSourceObject(step: formStep, parent: nil)
+        
+        XCTAssertEqual(dataSource.itemGroups.count, 1)
+        guard let itemGroup = dataSource.itemGroups.first as? RSDChoicePickerTableItemGroup,
+            let tableItem = itemGroup.items.first
+            else {
+                XCTFail("Failed to create expected type. \(dataSource.itemGroups)")
+                return
+        }
+        
+        // Before selecting an answer because the input field is *not* optional, the answer is
+        // not valid.
+        XCTAssertFalse(dataSource.allAnswersValid())
+                
+        do {
+            let _ = try dataSource.selectAnswer(item: tableItem, at: IndexPath(row: 0, section: 0))
+        } catch let err {
+            XCTFail("Failed to select item group. \(err)")
+        }
+        
+        // After an answer has been selected, then the result is valid. This should be true even
+        // if the answer result value is nil.
+        XCTAssertTrue(dataSource.allAnswersValid())
+        
+        guard let aResult = dataSource.collectionResult().inputResults.first as? RSDAnswerResult
+            else {
+                XCTFail("Failed to add answer result")
+                return
+        }
+        
+        // But the answer result should use a nil value.
+        XCTAssertEqual(aResult.value as? Int, 0)
+    }
+    
     // Helper methods
     
     func createDataSource(for json: Data, with initialResult: RSDCollectionResult? = nil) -> RSDFormStepDataSourceObject? {

--- a/Research/ResearchTests/DataSource Tests/PickerDataSourceTests.swift
+++ b/Research/ResearchTests/DataSource Tests/PickerDataSourceTests.swift
@@ -217,7 +217,7 @@ class PickerDataSourceTests: XCTestCase {
         let expectedRows = [1, 30]
         let expectedMinutes = 1
         let expectedSeconds = 30
-        let expectedText = "1:30"
+        let expectedText = "01:30"
         
         if let rows = picker.selectedRows(from: inputAnswer) {
             XCTAssertEqual(rows, expectedRows)
@@ -268,7 +268,7 @@ class PickerDataSourceTests: XCTestCase {
         let expectedRows = [1, 30]
         let expectedHours = 1
         let expectedMinutes = 30
-        let expectedText = "1:30"
+        let expectedText = "01:30"
         
         if let rows = picker.selectedRows(from: inputAnswer) {
             XCTAssertEqual(rows, expectedRows)


### PR DESCRIPTION
Found some more peanuts

First, there is an issue that iOS 13 formats duration strings differently the documentation for a `DurationFormatter`. This was causing tests to fail if and only if the target was iOS 13. When I took a look at what was happening, I feel that this is a fix for how it *should* behave rather than a bug introduced so I took the approach of fixing it for older iOS versions. Now, unit tests should pass for both iOS 12 and iOS 13.

Second, found an issue where if `nil` is being used as the placeholder for a choice value on an input field that is *not* optional, then it is never considered a valid answer even once it is selected. Fixed by checking for selection state rather than for `nil` answer value.

Finally, discovered that the default answer was *not* being properly set for a choice options field and fixed that.