### PR TITLE
Allow customizing the task overview step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ notifications:
   email:
   - apple.builds@sagebase.org
 language: objective-c
-osx_image: xcode10.2
+osx_image: xcode11
 xcode_workspace: Research.xcworkspace
 xcode_scheme: RSDCatalog
 cache:

--- a/Research/Research-UnitTest/Info.plist
+++ b/Research/Research-UnitTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-iOS.plist
+++ b/Research/Research/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-macOS.plist
+++ b/Research/Research/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Research/Research/Info-tvOS.plist
+++ b/Research/Research/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-watchOS.plist
+++ b/Research/Research/Info-watchOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/RSDOverviewStep.swift
+++ b/Research/Research/RSDOverviewStep.swift
@@ -36,8 +36,32 @@ import Foundation
 /// `RSDOverviewStep` extends the `RSDUIStep` to include general overview information about an activity
 /// including what permissions are required by this task. Without these preconditions, the task cannot
 /// measure or collect the data needed for this task.
-public protocol RSDOverviewStep : RSDUIStep, RSDStandardPermissionsStep {
+public protocol RSDOverviewStep : class, RSDUIStep, RSDStandardPermissionsStep {
+    
+    /// For an overview step, the title is readwrite.
+    var title: String? { get set }
+    
+    /// For an overview step, the text is readwrite.
+    var text: String? { get set }
+    
+    /// For an overview step, the detail is readwrite.
+    var detail: String? { get set }
+    
+    /// The learn more action for the task that this overview step is describing.
+    var learnMoreAction: RSDUIAction? { get set }
     
     /// The icons that are used to define the list of things you will need for an active task.
     var icons: [RSDIconInfo]? { get }
+}
+
+extension RSDTask {
+    
+    /// Look to see if the first step in this task is an overview step and if so, return that
+    /// step. Since the overview step is a class, then it can be mutated in-place without having
+    /// to mutate the step navigators method of containing those steps.
+    public var overviewStep: RSDOverviewStep? {
+        var taskResult: RSDTaskResult = RSDTaskResultObject(identifier: self.identifier)
+        let step = self.stepNavigator.step(after: nil, with: &taskResult).step
+        return step as? RSDOverviewStep
+    }
 }

--- a/Research/Research/RSDOverviewStepObject.swift
+++ b/Research/Research/RSDOverviewStepObject.swift
@@ -42,8 +42,27 @@ open class RSDOverviewStepObject : RSDUIStepObject, RSDOverviewStep {
         case icons
     }
     
+    /// For this implementation of the overview step, the learn more action is included in the
+    /// readwrite dictionary of actions.
+    open var learnMoreAction: RSDUIAction? {
+        get {
+            return self.actions?[.navigation(.learnMore)]
+        }
+        set {
+            guard let action = newValue else {
+                self.actions?[.navigation(.learnMore)] = nil
+                return
+            }
+            var actions = self.actions ?? [:]
+            actions[.navigation(.learnMore)] = action
+            self.actions = actions
+        }
+    }
+    
     /// The icons that are used to define the list of things you will need for an active task.
-    open var icons: [RSDIconInfo]?
+    /// These should *not* be readwrite since "What you will need" should be consistent across
+    /// uses of the activity.
+    open private(set) var icons: [RSDIconInfo]?
     
     /// Default type is `.overview`.
     open override class func defaultType() -> RSDStepType {

--- a/Research/ResearchLocation/Info.plist
+++ b/Research/ResearchLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 </dict>

--- a/Research/ResearchLocationTests/Info.plist
+++ b/Research/ResearchLocationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 </dict>

--- a/Research/ResearchMotion/Info.plist
+++ b/Research/ResearchMotion/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 </dict>

--- a/Research/ResearchMotionTests/Info.plist
+++ b/Research/ResearchMotionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 </dict>

--- a/Research/ResearchRecorders/Info-iOS.plist
+++ b/Research/ResearchRecorders/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 </dict>

--- a/Research/ResearchTests/Info-iOS.plist
+++ b/Research/ResearchTests/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 </dict>

--- a/Research/ResearchUI/Info-iOS.plist
+++ b/Research/ResearchUI/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 </dict>

--- a/Research/ResearchUITests/Info.plist
+++ b/Research/ResearchUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5</string>
+	<string>2.6</string>
 	<key>CFBundleVersion</key>
 	<string>72</string>
 </dict>


### PR DESCRIPTION
By explicitly defining the overview step as a `class` this allows that *one* step to be mutated in place without having to copy and replace all the steps or know anything about the step navigator or task that is backing the task.

While we have avoided using classes to enforce immutability of the task, this feels like the exception where a mutate in place is appropriate *and* easier to comprehend for our contract developers.