### PR TITLE
Add a app active listener to the motion authorization

### DIFF
--- a/Research/ResearchMotion/RSDMotionAuthorization.swift
+++ b/Research/ResearchMotion/RSDMotionAuthorization.swift
@@ -48,6 +48,29 @@ public final class RSDMotionAuthorization : RSDAuthorizationAdaptor {
     
     public static let shared = RSDMotionAuthorization()
     
+    init() {
+        let observer = NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: .main) { [weak self] (_) in
+            self?.refreshCachedAuthorization()
+        }
+        self._activeAppObserver = observer
+        refreshCachedAuthorization()
+    }
+    
+    deinit {
+        if let observer = self._activeAppObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        self._activeAppObserver = nil
+    }
+    
+    private var _activeAppObserver: Any?
+    func refreshCachedAuthorization() {
+        if RSDMotionAuthorization._cachedAuthorizationStatus() == .authorized {
+            RSDMotionAuthorization.requestAuthorization { (_, _) in
+            }
+        }
+    }
+    
     /// This adaptor is intended for checking for motion sensor permissions.
     public let permissions: [RSDPermissionType] = [RSDStandardPermissionType.motion]
     


### PR DESCRIPTION
Use the app notification for did become active to refresh the cached authorization whenever the app becomes active. This will handle the case where the participant has previously authorized access to the motion sensors, but has subsequently turned OFF that authorization.

Note: realistically, this is uncommon and will not cause a serious failure, but since testers will run this scenario, may as well fix it.