### PR TITLE
Enable cancel and dismiss callbacks

### DIFF
--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -711,8 +711,9 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
     }
 	
 	/// Hook to let tasks know that user decided not to cancel.
-	open func keepGoing() {
-		//Defaults to do nothing.  Allows tasks to get called back if user decides to keep going instead of canceling.
+	/// Default action is to do nothing, this method is to allow subclasses to override and have an action.
+	open func didNotCancel() {
+		//Defaults to do nothing.
 	}
 
 	/// Finish canceling the task. This is called once the cancel is confirmed by the user.
@@ -1215,7 +1216,7 @@ public protocol RSDCancelActionController : RSDStepController, RSDAlertPresenter
     func cancelTask(shouldSave: Bool)
 
 	/// This is called when the user decides to keep going with the task instead of canceling it
-	func keepGoing()
+	func didNotCancel()
 }
 
 extension RSDCancelActionController {
@@ -1247,7 +1248,7 @@ extension RSDCancelActionController {
         
         // Always add a choice to keep going.
         let keepGoing = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_CONTINUE"), style: .cancel) { (_) in
-            self.keepGoing()
+            self.didNotCancel()
         }
         actions.append(keepGoing)
         

--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -709,8 +709,13 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
     open func shouldConfirmCancel() -> Bool {
         return self.stepViewModel.rootPathComponent.shouldConfirmCancel()
     }
-    
-    /// Finish canceling the task. This is called once the cancel is confirmed by the user.
+	
+	/// Hook to let tasks know that user decided not to cancel.
+	open func keepGoing() {
+		//Defaults to do nothing.  Allows tasks to get called back if user decides to keep going instead of canceling.
+	}
+
+	/// Finish canceling the task. This is called once the cancel is confirmed by the user.
     ///
     /// - parameter shouldSave: Should the task progress be saved?
     open func cancelTask(shouldSave: Bool) {
@@ -1208,6 +1213,9 @@ public protocol RSDCancelActionController : RSDStepController, RSDAlertPresenter
     ///
     /// - parameter shouldSave: Should the task progress be saved?
     func cancelTask(shouldSave: Bool)
+
+	/// This is called when the user decides to keep going with the task instead of canceling it
+	func keepGoing()
 }
 
 extension RSDCancelActionController {
@@ -1239,7 +1247,7 @@ extension RSDCancelActionController {
         
         // Always add a choice to keep going.
         let keepGoing = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_CONTINUE"), style: .cancel) { (_) in
-            // Do nothing, just hide the alert
+            self.keepGoing()
         }
         actions.append(keepGoing)
         

--- a/Research/ResearchUI/iOS/View Controllers/RSDWebViewController.swift
+++ b/Research/ResearchUI/iOS/View Controllers/RSDWebViewController.swift
@@ -65,7 +65,7 @@ open class RSDWebViewController: UIViewController, WKNavigationDelegate {
     /// Convenience method for instantiating a web view controller that is the root view controller for a
     /// navigation controller.
     open class func instantiateController(using designSystem: RSDDesignSystem = RSDDesignSystem(), action: RSDWebViewUIAction? = nil) -> (RSDWebViewController, UINavigationController) {
-        let webVC = RSDWebViewController()
+        let webVC = self.init()
         let navVC = UINavigationController(rootViewController: webVC)
 
         // Set up the model.


### PR DESCRIPTION
* Provide a mechanism to know when the user dismisses the cancel alert in `RSDStepViewController`
* Make `RSDWebViewController`'s static builder function subclass-able 