### PR TITLE
Decode survey rules using override

### DIFF
--- a/Research/Research/RSDCollectionResultObject.swift
+++ b/Research/Research/RSDCollectionResultObject.swift
@@ -80,8 +80,8 @@ public struct RSDCollectionResultObject : RSDCollectionResult, RSDNavigationResu
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.identifier = try container.decode(String.self, forKey: .identifier)
         self.skipToIdentifier = try container.decodeIfPresent(String.self, forKey: .skipToIdentifier)
-        self.startDate = try container.decode(Date.self, forKey: .startDate)
-        self.endDate = try container.decode(Date.self, forKey: .endDate)
+        self.startDate = try container.decodeIfPresent(Date.self, forKey: .startDate) ?? Date()
+        self.endDate = try container.decodeIfPresent(Date.self, forKey: .endDate) ?? Date()
         self.type = try container.decode(RSDResultType.self, forKey: .type)
         
         let resultsContainer = try container.nestedUnkeyedContainer(forKey: .inputResults)

--- a/Research/Research/RSDErrorResultObject.swift
+++ b/Research/Research/RSDErrorResultObject.swift
@@ -35,6 +35,9 @@ import Foundation
 
 /// `RSDErrorResult` is a result that holds information about an error.
 public struct RSDErrorResultObject : RSDErrorResult, Codable {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
+        case identifier, type, _startDate = "startDate", _endDate = "endDate", errorDescription, errorDomain, errorCode
+    }
     
     /// The identifier associated with the task, step, or asynchronous action.
     public let identifier: String
@@ -43,10 +46,18 @@ public struct RSDErrorResultObject : RSDErrorResult, Codable {
     public let type: RSDResultType
     
     /// The start date timestamp for the result.
-    public var startDate: Date
+    public var startDate: Date {
+        get { _startDate ?? Date() }
+        set { _startDate = newValue }
+    }
+    private var _startDate: Date?
     
     /// The end date timestamp for the result.
-    public var endDate: Date
+    public var endDate: Date {
+        get { _endDate ?? Date() }
+        set { _endDate = newValue }
+    }
+    private var _endDate: Date?
     
     /// A description associated with an `NSError`.
     public let errorDescription: String
@@ -57,10 +68,6 @@ public struct RSDErrorResultObject : RSDErrorResult, Codable {
     /// The error code associated with an `NSError`.
     public let errorCode: Int
     
-    private enum CodingKeys : String, CodingKey, CaseIterable {
-        case identifier, type, startDate, endDate, errorDescription, errorDomain, errorCode
-    }
-    
     /// Initialize using a description, domain, and code.
     /// - parameters:
     ///     - identifier: The identifier for the result.
@@ -70,8 +77,8 @@ public struct RSDErrorResultObject : RSDErrorResult, Codable {
     public init(identifier: String, description: String, domain: String, code: Int) {
         self.identifier = identifier
         self.type = .error
-        self.startDate = Date()
-        self.endDate = Date()
+        self._startDate = Date()
+        self._endDate = Date()
         self.errorDescription = description
         self.errorDomain = domain
         self.errorCode = code
@@ -84,8 +91,8 @@ public struct RSDErrorResultObject : RSDErrorResult, Codable {
     public init(identifier: String, error: Error) {
         self.identifier = identifier
         self.type = .error
-        self.startDate = Date()
-        self.endDate = Date()
+        self._startDate = Date()
+        self._endDate = Date()
         self.errorDescription = (error as NSError).localizedDescription
         self.errorDomain = (error as NSError).domain
         self.errorCode = (error as NSError).code

--- a/Research/Research/RSDFactory.swift
+++ b/Research/Research/RSDFactory.swift
@@ -623,22 +623,6 @@ open class RSDFactory {
         }
     }
     
-    open func decodeSurveyRules(from rulesContainer: UnkeyedDecodingContainer) throws -> [RSDSurveyRule] {
-        var container = rulesContainer
-        var surveyRules = [RSDSurveyRule]()
-        while !container.isAtEnd {
-            let nestedDecoder = try container.superDecoder()
-            let surveyRule = try self.decodeSurveyRule(from: nestedDecoder)
-            surveyRules.append(surveyRule)
-        }
-        return surveyRules
-    }
-    
-    open func decodeSurveyRule(from decoder: Decoder) throws -> RSDSurveyRule {
-        return try JsonSurveyRuleObject(from: decoder)
-    }
-    
-    
     // MARK: Range factory
     
     /// Overridable  function for decoding the range from the decoder. The default implementation will

--- a/Research/Research/RSDFileResultObject.swift
+++ b/Research/Research/RSDFileResultObject.swift
@@ -43,10 +43,18 @@ public struct RSDFileResultObject : RSDFileResult, Codable {
     public let type: RSDResultType
     
     /// The start date timestamp for the result.
-    public var startDate: Date = Date()
+    public var startDate: Date {
+        get { _startDate ?? Date() }
+        set { _startDate = newValue }
+    }
+    private var _startDate: Date?
     
     /// The end date timestamp for the result.
-    public var endDate: Date = Date()
+    public var endDate: Date {
+        get { _endDate ?? Date() }
+        set { _endDate = newValue }
+    }
+    private var _endDate: Date?
     
     /// The system clock uptime when the recorder was started (if applicable).
     public var startUptime: TimeInterval?
@@ -69,7 +77,7 @@ public struct RSDFileResultObject : RSDFileResult, Codable {
     public var contentType: String?
     
     private enum CodingKeys : String, CodingKey, CaseIterable {
-        case identifier, type, startDate, endDate, startUptime, relativePath, contentType
+        case identifier, type, _startDate = "startDate", _endDate = "endDate", startUptime, relativePath, contentType
     }
     
     /// Default initializer for this object.

--- a/Research/Research/RSDResult.swift
+++ b/Research/Research/RSDResult.swift
@@ -43,7 +43,7 @@ import Foundation
 /// conformance to `Decodable`. This allows using class objects that cannot be extended to conform to the
 /// `Decodable` protocol, such as `ORKResult` classes.
 ///
-public protocol RSDResult : Encodable {
+public protocol RSDResult : Result {
     
     /// The identifier associated with the task, step, or asynchronous action.
     var identifier: String { get }

--- a/Research/Research/Result.swift
+++ b/Research/Research/Result.swift
@@ -39,7 +39,7 @@ import Foundation
 
 /// A `Result` is any data result that should be included with an `Assessment`. The base level
 /// interface only has an `identifier` and does not include any other properties.
-public protocol Result : Encodable, NSCopying {
+public protocol Result : Encodable {
 
     /// The identifier for the result.
     var identifier: String { get }


### PR DESCRIPTION
Realized that decoding the survey rules has to be done at the init() level because the rules do not have a polymorphic "type" keyword on each rule.