### PR TITLE
Update step history path for task results

### DIFF
--- a/Research/MigrationNotes_v3.1.md
+++ b/Research/MigrationNotes_v3.1.md
@@ -29,8 +29,8 @@ or "detail". In ResearchUI, the `UILabel`  that was mapped to `text` will now ma
 
 In a future version, the `RSDResult` protocol will be replaced with the `Result` protocol. For this version, 
 `RSDAnswerResult` is deprecated and replaced with `AnswerResult`. Likewise, `RSDAnswerResultObject` has
-been deprecated in favor of `AnswerResultObject`. Eventually, this will mean that results will *not* require a 
-`startDate` and `endDate` for all results. They will still require `identifier` and `type` since those are used in 
+been deprecated in favor of `AnswerResultObject`. Eventually, this will mean that results will *not* require an 
+ `endDate` for all results. They will still require `identifier` and `type` since those are used in 
 serialization and in finding the result for a matching step.
 
 The `RSDAnswerResultType` has been replaced with `AnswerType` which is a protocol that conforms to the 

--- a/Research/MigrationNotes_v3.4.md
+++ b/Research/MigrationNotes_v3.4.md
@@ -1,6 +1,0 @@
-#  Migration Notes -> 3.4
-
-
-
-
-

--- a/Research/MigrationNotes_v3.4.md
+++ b/Research/MigrationNotes_v3.4.md
@@ -1,0 +1,6 @@
+#  Migration Notes -> 3.4
+
+
+
+
+

--- a/Research/ReleaseNotes_v3.4.md
+++ b/Research/ReleaseNotes_v3.4.md
@@ -1,0 +1,8 @@
+#  Release Notes -> 3.4
+
+No migration should be required. This version changes the `RSDTaskResult.stepHistory` to include an instance 
+of the step result for *each* display of that step so that there can be duplicates of the same step identifier in the
+results.
+
+
+

--- a/Research/Research-UnitTest/Info.plist
+++ b/Research/Research-UnitTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research.xcodeproj/project.pbxproj
+++ b/Research/Research.xcodeproj/project.pbxproj
@@ -1565,7 +1565,7 @@
 		FF4329E123A044A20027288F /* RSDResourceImageDataObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDResourceImageDataObject.swift; sourceTree = "<group>"; };
 		FF432A0B23A05BA20027288F /* Geometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geometry.swift; sourceTree = "<group>"; };
 		FF432A1B23A2FBE80027288F /* ThemeImageViewOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeImageViewOwner.swift; sourceTree = "<group>"; };
-		FF518F8024AC089B003E9DAB /* MigrationNotes_v3.4.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = MigrationNotes_v3.4.md; sourceTree = "<group>"; };
+		FF518F8024AC089B003E9DAB /* ReleaseNotes_v3.4.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ReleaseNotes_v3.4.md; sourceTree = "<group>"; };
 		FF580BF31F7E3764009B3EE9 /* RSDActiveUIStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDActiveUIStepObject.swift; sourceTree = "<group>"; };
 		FF580BF51F7ED80B009B3EE9 /* Dictionary+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Utilities.swift"; sourceTree = "<group>"; };
 		FF5C4C1C1F8C872500F311BA /* RSDTaskController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTaskController.swift; sourceTree = "<group>"; };
@@ -2570,7 +2570,7 @@
 				FFE0BD452445436100B941BC /* MigrationNotes_v3.1.md */,
 				FFF433FD2446428B00C5F466 /* MigrationNotes_v3.2.md */,
 				FFA94E58244E35DB00A706F2 /* MigrationNotes_v3.3.md */,
-				FF518F8024AC089B003E9DAB /* MigrationNotes_v3.4.md */,
+				FF518F8024AC089B003E9DAB /* ReleaseNotes_v3.4.md */,
 				FF72B2331F6859D3004C6F15 /* Research */,
 				FF72B23E1F6859D3004C6F15 /* ResearchTests */,
 				F875575720807E2300235078 /* Research-UnitTest */,

--- a/Research/Research.xcodeproj/project.pbxproj
+++ b/Research/Research.xcodeproj/project.pbxproj
@@ -1565,6 +1565,7 @@
 		FF4329E123A044A20027288F /* RSDResourceImageDataObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDResourceImageDataObject.swift; sourceTree = "<group>"; };
 		FF432A0B23A05BA20027288F /* Geometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geometry.swift; sourceTree = "<group>"; };
 		FF432A1B23A2FBE80027288F /* ThemeImageViewOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeImageViewOwner.swift; sourceTree = "<group>"; };
+		FF518F8024AC089B003E9DAB /* MigrationNotes_v3.4.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = MigrationNotes_v3.4.md; sourceTree = "<group>"; };
 		FF580BF31F7E3764009B3EE9 /* RSDActiveUIStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDActiveUIStepObject.swift; sourceTree = "<group>"; };
 		FF580BF51F7ED80B009B3EE9 /* Dictionary+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Utilities.swift"; sourceTree = "<group>"; };
 		FF5C4C1C1F8C872500F311BA /* RSDTaskController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTaskController.swift; sourceTree = "<group>"; };
@@ -2569,6 +2570,7 @@
 				FFE0BD452445436100B941BC /* MigrationNotes_v3.1.md */,
 				FFF433FD2446428B00C5F466 /* MigrationNotes_v3.2.md */,
 				FFA94E58244E35DB00A706F2 /* MigrationNotes_v3.3.md */,
+				FF518F8024AC089B003E9DAB /* MigrationNotes_v3.4.md */,
 				FF72B2331F6859D3004C6F15 /* Research */,
 				FF72B23E1F6859D3004C6F15 /* ResearchTests */,
 				F875575720807E2300235078 /* Research-UnitTest */,

--- a/Research/Research/Info-iOS.plist
+++ b/Research/Research/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-macOS.plist
+++ b/Research/Research/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Research/Research/Info-tvOS.plist
+++ b/Research/Research/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-watchOS.plist
+++ b/Research/Research/Info-watchOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/RSDCollectionResult.swift
+++ b/Research/Research/RSDCollectionResult.swift
@@ -37,17 +37,9 @@ import Foundation
 /// `RSDCollectionResult` is used include multiple results associated with a single step or async action that
 /// may have more that one result.
 public protocol RSDCollectionResult : CollectionResult, RSDAnswerResultFinder {
-    
-    /// The list of input results associated with this step. These are generally assumed to be answers to
-    /// field inputs, but they are not required to implement the `RSDAnswerResult` protocol.
-    var inputResults: [RSDResult] { get set }
 }
 
 extension RSDCollectionResult {
-    
-    public var children: [RSDResult] {
-        inputResults
-    }
     
     /// Find a result within this collection.
     /// - parameter identifier: The identifier associated with the result.

--- a/Research/Research/RSDPathComponent.swift
+++ b/Research/Research/RSDPathComponent.swift
@@ -185,8 +185,8 @@ extension RSDPathComponent {
     }
     
     /// String representing the current order of steps to this point in the task.
-    public var stepPath: String {
-        return self.taskResult.stepHistory.map( {$0.identifier }).joined(separator: ", ")
+    public var nodePathHistory: String {
+        return taskResult.stepHistory.map { $0.identifier }.joined(separator: ", ")
     }
     
     /// Is this the first step in the task?

--- a/Research/Research/RSDStepViewModel.swift
+++ b/Research/Research/RSDStepViewModel.swift
@@ -164,7 +164,7 @@ open class RSDStepViewModel : NSObject, RSDStepViewPathComponent {
     
     /// The description of the path.
     override open var description: String {
-        return "\(type(of: self)): \(fullPath) steps: [\(stepPath)]"
+        return "\(type(of: self)): \(fullPath) steps: [\(fullPath)]"
     }
     
     // MARK: UIAction handling

--- a/Research/Research/RSDTaskResult.swift
+++ b/Research/Research/RSDTaskResult.swift
@@ -102,7 +102,7 @@ extension RSDTaskResult  {
     
     /// Remove the nodePath from `stepIdentifier` to the end of the result set.
     /// - parameter stepIdentifier:  The identifier of the result associated with the given step.
-    /// - returns: The previous results or `nil` if there wasn't one.
+    /// - returns: The previous results or `nil` if there weren't any.
     @discardableResult
     mutating public func removeStepHistory(from stepIdentifier: String) -> Array<RSDResult>? {
         if let idx = nodePath.lastIndex(of: stepIdentifier) {

--- a/Research/Research/RSDTaskResultObject.swift
+++ b/Research/Research/RSDTaskResultObject.swift
@@ -38,7 +38,7 @@ import JsonModel
 /// schema identifier, and asynchronous results.
 public struct RSDTaskResultObject : RSDTaskRunResult, Codable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
-        case identifier, type, startDate, endDate, taskRunUUID, schemaInfo, stepHistory, asyncResults
+        case identifier, type, startDate, endDate, taskRunUUID, schemaInfo, stepHistory, asyncResults, nodePath
     }
     
     /// The identifier associated with the task, step, or asynchronous action.
@@ -66,6 +66,9 @@ public struct RSDTaskResultObject : RSDTaskRunResult, Codable {
     /// A list of all the asynchronous results for this task. The list should include uniquely identified results.
     public var asyncResults: [RSDResult]?
     
+    /// The path to the current result.
+    public var nodePath: [String] = []
+    
     /// Default initializer for this object.
     ///
     /// - parameters:
@@ -90,6 +93,7 @@ public struct RSDTaskResultObject : RSDTaskRunResult, Codable {
         self.startDate = try container.decode(Date.self, forKey: .startDate)
         self.endDate = try container.decode(Date.self, forKey: .endDate)
         self.taskRunUUID = try container.decode(UUID.self, forKey: .taskRunUUID)
+        self.nodePath = try container.decodeIfPresent([String].self, forKey: .nodePath) ?? []
         
         if container.contains(.schemaInfo) {
             let nestedDecoder = try container.superDecoder(forKey: .schemaInfo)
@@ -115,6 +119,7 @@ public struct RSDTaskResultObject : RSDTaskRunResult, Codable {
         try container.encode(startDate, forKey: .startDate)
         try container.encode(endDate, forKey: .endDate)
         try container.encode(taskRunUUID, forKey: .taskRunUUID)
+        try container.encode(nodePath, forKey: .nodePath)
         
         let nestedEncoder = container.superEncoder(forKey: .schemaInfo)
         try encoder.factory.encodeSchemaInfo(from: self, to: nestedEncoder)
@@ -167,6 +172,8 @@ extension RSDTaskResultObject : DocumentableStruct {
             return .init(propertyType: .reference(RSDSchemaInfoObject.documentableType()))
         case .stepHistory, .asyncResults:
             return .init(propertyType: .interfaceArray("\(RSDResult.self)"))
+        case .nodePath:
+            return .init(propertyType: .primitiveArray(.string))
         }
     }
     

--- a/Research/Research/RSDTaskViewModel.swift
+++ b/Research/Research/RSDTaskViewModel.swift
@@ -84,7 +84,7 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
     
     /// The description of the path.
     override open var description: String {
-        return "\(type(of: self)): \(fullPath) steps: [\(stepPath)]"
+        return "\(type(of: self)): \(fullPath) steps: [\(nodePathHistory)]"
     }
     
     
@@ -370,9 +370,9 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
         // Before loading the step controller, add a new instance of the step result to the step history to
         // indicate that the step was "visited" even if it was not displayed b/c the task controller didn't
         // return a step controller.
-        if self.taskResult.findResult(for: step) == nil {
-            let stepResult = step.instantiateStepResult()
-            self.taskResult.appendStepHistory(with: stepResult)
+        
+        if self.taskResult.stepHistory.last?.identifier != step.identifier  {
+            self.taskResult.appendStepHistory(with: step.instantiateStepResult())
         }
 
         guard let stepController = self.taskController?.stepController(for: step, with: self)
@@ -394,6 +394,11 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
         // then return that.
         if ((step is RSDTaskInfoStep) || (step is RSDSectionStep)),
             let childPath = self.childPaths[step.identifier] {
+            
+            if self.taskResult.stepHistory.last?.identifier != step.identifier  {
+                self.taskResult.appendStepHistory(with: childPath.pathResult())
+            }
+            
             return (childPath, nil)
         }
         return self.pathComponent(for: step)

--- a/Research/Research/Result-KotlinModel.swift
+++ b/Research/Research/Result-KotlinModel.swift
@@ -83,12 +83,12 @@ public protocol CollectionResult : RSDResult, AnswerFinder {
     /// to a service call, or the results from a form where all the fields are displayed together
     /// and the results do not represent a linear path. The results within this set should each
     /// have a unique identifier.
-    var children: [RSDResult] { get }
+    var inputResults: [RSDResult] { get set }
 }
 
 public extension CollectionResult {
     func findAnswer(with identifier: String) -> AnswerResult? {
-        self.children.first(where: { $0.identifier == identifier }) as? AnswerResult
+        self.inputResults.first(where: { $0.identifier == identifier }) as? AnswerResult
     }
 }
 
@@ -102,7 +102,11 @@ public protocol BranchNodeResult : CollectionResult {
     /// The running history of the nodes that were traversed as a part of running an assessment.
     /// This will only include a subset (section) that is the path defined at this level of the
     /// overall assessment hierarchy.
-    var pathHistoryResults: [RSDResult] { get }
+    var stepHistory: [RSDResult] { get set }
+    
+    /// The path traversed by this branch. The `nodePath` is specific to the navigation implemented
+    /// on iOS and is different from the `path` implementation in the Kotlin-native framework.
+    var nodePath: [String] { get set }
 }
 
 /// An `AssessmentResult` is the top-level `Result` for an assessment.
@@ -116,3 +120,111 @@ public protocol AssessmentResult : BranchNodeResult {
     /// The `versionString` may be a semantic version, timestamp, or sequential revision integer.
     var versionString: String? { get }
 }
+
+
+// TODO: Remove once we have parity. syoung 06/30/2020
+
+///**
+// * A [Result] is any data result that should be included with an [Assessment]. The base level interface only has an
+// * [identifier] and does not include any other properties. The [identifier] in this case may be either the
+// * [ResultMapElement.resultIdentifier] *or* the [ResultMapElement.identifier] if the result identifier is undefined.
+// *
+// * TODO: syoung 01/10/2020 figure out a clean-ish way to encode the result and include in the base interface. In Swift, the `RSDResult` conforms to the `Encodable` protocol so it can be encoded to a JSON dictionary. Is there a Kotlin equivalent?
+// *
+// */
+//interface Result {
+//    fun copyResult(identifier: String = this.identifier) : Result
+//
+//    /**
+//     * The identifier for the result. This identifier maps to the [ResultMapElement.resultIdentifier] for an associated
+//     * [Assessment] element.
+//     */
+//    val identifier: String
+//
+//    /**
+//     * The start date timestamp for the result.
+//     */
+//    var startDateString: String
+//
+//    /**
+//     * The end date timestamp for the result.
+//     */
+//    var endDateString: String?
+//}
+//
+//fun MutableSet<Result>.copyResults() = map { it.copyResult() }.toMutableSet()
+//fun MutableList<Result>.copyResults() = map { it.copyResult() }.toMutableList()
+//
+///**
+// * A [CollectionResult] is used to describe the output of a [Section], [FormStep], or [Assessment].
+// */
+//interface CollectionResult : Result {
+//    override fun copyResult(identifier: String) : CollectionResult
+//
+//    /**
+//     * The [inputResults] is a set that contains results that are recorded in parallel to the user-facing node
+//     * path. This can be the async results of a sensor recorder, a response to a service call, or the results from a
+//     * form where all the fields are displayed together and the results do not represent a linear path. The results
+//     * within this set should each have a unique identifier.
+//     */
+//    var inputResults: MutableSet<Result>
+//}
+//
+///**
+// * The [BranchNodeResult] is the result created for a given level of navigation of a node tree. The
+// * [pathHistoryResults] is additive where each time a node is traversed, it is added to the list.
+// */
+//interface BranchNodeResult : CollectionResult {
+//    override fun copyResult(identifier: String) : BranchNodeResult
+//
+//    /**
+//     * The [pathHistoryResults] includes the history of the [Node] results that were traversed as a part of running an
+//     * [Assessment]. This will only include a subset that is the path defined at this level of the overall [Assessment]
+//     * hierarchy.
+//     */
+//    var pathHistoryResults: MutableList<Result>
+//
+//    /**
+//     * The path traversed by this branch.
+//     */
+//    val path: MutableList<PathMarker>
+//}
+//
+//@Serializable
+//data class PathMarker(val identifier: String, val direction: NavigationPoint.Direction)
+//
+///**
+// * An [AssessmentResult] is the top-level [Result] for an [Assessment].
+// */
+//interface AssessmentResult : BranchNodeResult {
+//    override fun copyResult(identifier: String) : AssessmentResult
+//
+//    /**
+//     * A unique identifier for this run of the assessment. This property is defined as readwrite to allow the
+//     * controller for the task to set this on the [AssessmentResult] children included in this run.
+//     */
+//    var runUUIDString: String
+//
+//    /**
+//     * The [versionString] may be a semantic version, timestamp, or sequential revision integer. This should map to the
+//     * [Assessment.versionString].
+//     */
+//    val versionString: String?
+//}
+//
+///**
+// * An [AnswerResult] is used to hold a serializable answer to a question or measurement.
+// */
+//interface AnswerResult : Result {
+//    override fun copyResult(identifier: String) : AnswerResult
+//
+//    /**
+//     * Optional property for defining additional information about the answer expected for this result.
+//     */
+//    val answerType: AnswerType?
+//
+//    /**
+//     * The answer held by this result.
+//     */
+//    var jsonValue: JsonElement?
+//}

--- a/Research/ResearchLocation/Info.plist
+++ b/Research/ResearchLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 </dict>

--- a/Research/ResearchLocationTests/Info.plist
+++ b/Research/ResearchLocationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 </dict>

--- a/Research/ResearchMotion/Info.plist
+++ b/Research/ResearchMotion/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 </dict>

--- a/Research/ResearchMotionTests/Info.plist
+++ b/Research/ResearchMotionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 </dict>

--- a/Research/ResearchTests/Info-iOS.plist
+++ b/Research/ResearchTests/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 </dict>

--- a/Research/ResearchTests/Navigation Tests/TaskControllerTests.swift
+++ b/Research/ResearchTests/Navigation Tests/TaskControllerTests.swift
@@ -95,7 +95,7 @@ class TaskControllerTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(currentNode.stepPath, "stepA, stepB, stepC")
+        XCTAssertEqual(currentNode.nodePathHistory, "stepA, stepB, stepC")
         
         // check that the path parent has the correct current step
         let currentParentStep = currentNode.parent
@@ -138,7 +138,7 @@ class TaskControllerTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(currentNode.stepPath, "stepX, stepY")
+        XCTAssertEqual(currentNode.nodePathHistory, "stepX, stepY, stepZ, stepY")
         
         // check that the path parent has the correct current step
         let currentParentStep = currentNode.parent
@@ -190,6 +190,8 @@ class TaskControllerTests: XCTestCase {
         XCTAssertNotNil(beforeAnswerResult3)
         XCTAssertEqual(beforeAnswerResult3?.value as? String, "step3")
         
+        XCTAssertEqual(taskController.taskViewModel.taskResult.nodePath, ["introduction", "step1", "step2", "step3"])
+        
         // Now go back one step. The expectation is that the state tracking will move back to step2 and the
         // previous answers to both step2 and step3 will be stored in the previous results.
         taskController.goBack()
@@ -198,11 +200,13 @@ class TaskControllerTests: XCTestCase {
         XCTAssertNotNil(stepTo)
         XCTAssertEqual(stepTo?.stepViewModel?.identifier, "step2")
         
+        XCTAssertEqual(taskController.taskViewModel.taskResult.nodePath, ["introduction", "step1", "step2"])
+        
         let direction = taskController.show_calledDirection
         XCTAssertNotNil(direction)
         XCTAssertEqual(direction ?? RSDStepDirection.none, RSDStepDirection.reverse)
         
-        XCTAssertEqual(taskController.taskViewModel.stepPath, "introduction, step1, step2")
+        XCTAssertEqual(taskController.taskViewModel.nodePathHistory, "introduction, step1, step2, step3, step2")
         
         let currentResult = taskController.taskViewModel.currentNode?.taskResult.stepHistory.last
         XCTAssertNotNil(currentResult)
@@ -256,7 +260,7 @@ class TaskControllerTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(currentNode.stepPath, "stepX, stepY")
+        XCTAssertEqual(currentNode.nodePathHistory, "stepX, stepY")
         
         // check that the path parent has the correct current step
         let currentParentStep = currentNode.parent
@@ -299,7 +303,7 @@ class TaskControllerTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(currentNode.stepPath, "stepA")
+        XCTAssertEqual(currentNode.nodePathHistory, "stepA")
         
         // check that the path parent has the correct current step
         let currentParentStep = currentNode.parent
@@ -337,7 +341,7 @@ class TaskControllerTests: XCTestCase {
         XCTAssertNotNil(direction)
         XCTAssertEqual(direction ?? RSDStepDirection.none, RSDStepDirection.forward)
         
-        XCTAssertEqual(taskController.taskViewModel.stepPath, "introduction, step1, step2, step3")
+        XCTAssertEqual(taskController.taskViewModel.nodePathHistory, "introduction, step1, step2, step3")
     }
     
     

--- a/Research/ResearchUI/Info-iOS.plist
+++ b/Research/ResearchUI/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 </dict>

--- a/Research/ResearchUITests/Info.plist
+++ b/Research/ResearchUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3</string>
+	<string>3.4</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
 </dict>


### PR DESCRIPTION

[Archive.zip](https://github.com/Sage-Bionetworks/SageResearch/files/4880578/Archive.zip)

@larssono @apratap 

This change introduces previous results into the step history for a task result. This will match the Kotlin-native implementation of the "stepHistory" key in the `taskResult.json` file of an archive. (Example attached)

Note: there are still some differences between this task result and the task result produced by the Kotlin-native implementation. Specifically:

### "nodePath" vs "path"

This is used while the task is running to keep track of the *current* step. The iOS implementation of navigation predates the Kotlin implementation. While the Kotlin implementation is simpler and cleaner, I did not feel it was advisable to attempt to duplicate it on iOS using the "if it ain't broke" philosophy. This key/value pair is included for the developers so that they can restore a task that is in progress and should be ignored by researchers. 

Since the object array is different between the iOS and Kotlin JSON files, I have given them different names.

### "schemaInfo" vs "versionString" and "assessmentIdentifier"

We will need to reconcile how the "Schema Identifier" and "Revision" should map to the "Task Identifier". Since this is still under discussion and may change with Bridge 2.0 I did not attempt to address this discrepancy with this PR.

### Type identifier within the JSON. "task" vs "assessment" and "section"

In the Kotlin implementation we have refined the navigation to differentiate between a "section" and an "assessment" where an Assessment is a stand-alone assessment and a section is only ever a part of that assessment. In the older iOS code that was originally modeled to maintain compatibility with ResearchKit 1.0, both an assessment and the sections within it were considered a "task" and would map to the same object (RSDTaskResult). A different PR will be forthcoming to address this.
