### PR TITLE
Refactor task result "type"

### DIFF
--- a/Research/ReleaseNotes.md
+++ b/Research/ReleaseNotes.md
@@ -1,0 +1,21 @@
+#  Release Notes 
+
+## Version 3.4
+
+No migration should be required. 
+
+This version changes the `RSDTaskResult.stepHistory` to include an instance 
+of the step result for *each* display of that step so that there can be duplicates of the same step identifier in the
+results.
+
+## Version 3.5
+
+No migration should be required. 
+
+This version introduces `SectionResultObject` and changes the protocol for
+`RSDTaskResult` to *not* include the schema, revision, and task run UUID. In actual usage, the top-level task 
+conforms to `RSDTaskRunResult` with a read/write `taskRunUUID` that is comparable to the Kotlin native 
+implementation of an `AssessmentResultObject`.  This change allows for only including the task run UUID at the
+top level of the task result JSON file.
+
+

--- a/Research/ReleaseNotes_v3.4.md
+++ b/Research/ReleaseNotes_v3.4.md
@@ -1,8 +1,0 @@
-#  Release Notes -> 3.4
-
-No migration should be required. This version changes the `RSDTaskResult.stepHistory` to include an instance 
-of the step result for *each* display of that step so that there can be duplicates of the same step identifier in the
-results.
-
-
-

--- a/Research/Research-UnitTest/Info.plist
+++ b/Research/Research-UnitTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research.xcodeproj/project.pbxproj
+++ b/Research/Research.xcodeproj/project.pbxproj
@@ -800,6 +800,10 @@
 		FF432A0E23A05BA20027288F /* Geometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF432A0B23A05BA20027288F /* Geometry.swift */; };
 		FF432A0F23A05BA20027288F /* Geometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF432A0B23A05BA20027288F /* Geometry.swift */; };
 		FF432A1C23A2FBE90027288F /* ThemeImageViewOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF432A1B23A2FBE80027288F /* ThemeImageViewOwner.swift */; };
+		FF5D2C4D24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5D2C4C24B3A7D5000EA4E5 /* SectionResultObject.swift */; };
+		FF5D2C4E24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5D2C4C24B3A7D5000EA4E5 /* SectionResultObject.swift */; };
+		FF5D2C4F24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5D2C4C24B3A7D5000EA4E5 /* SectionResultObject.swift */; };
+		FF5D2C5024B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5D2C4C24B3A7D5000EA4E5 /* SectionResultObject.swift */; };
 		FF61FA3223A459AD006B36C5 /* RSDResourceImageDataObject+Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF61FA3123A459AD006B36C5 /* RSDResourceImageDataObject+Platform.swift */; };
 		FF61FA3323A459AD006B36C5 /* RSDResourceImageDataObject+Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF61FA3123A459AD006B36C5 /* RSDResourceImageDataObject+Platform.swift */; };
 		FF61FA3423A459AD006B36C5 /* RSDResourceImageDataObject+Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF61FA3123A459AD006B36C5 /* RSDResourceImageDataObject+Platform.swift */; };
@@ -1524,12 +1528,13 @@
 		FF4329E123A044A20027288F /* RSDResourceImageDataObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDResourceImageDataObject.swift; sourceTree = "<group>"; };
 		FF432A0B23A05BA20027288F /* Geometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geometry.swift; sourceTree = "<group>"; };
 		FF432A1B23A2FBE80027288F /* ThemeImageViewOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeImageViewOwner.swift; sourceTree = "<group>"; };
-		FF518F8024AC089B003E9DAB /* ReleaseNotes_v3.4.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ReleaseNotes_v3.4.md; sourceTree = "<group>"; };
+		FF518F8024AC089B003E9DAB /* ReleaseNotes.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ReleaseNotes.md; sourceTree = "<group>"; };
 		FF580BF31F7E3764009B3EE9 /* RSDActiveUIStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDActiveUIStepObject.swift; sourceTree = "<group>"; };
 		FF580BF51F7ED80B009B3EE9 /* Dictionary+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Utilities.swift"; sourceTree = "<group>"; };
 		FF5C4C1C1F8C872500F311BA /* RSDTaskController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTaskController.swift; sourceTree = "<group>"; };
 		FF5C4C1E1F8C874300F311BA /* RSDStepController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDStepController.swift; sourceTree = "<group>"; };
 		FF5C4C311F8C9DC100F311BA /* RSDResultObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDResultObject.swift; sourceTree = "<group>"; };
+		FF5D2C4C24B3A7D5000EA4E5 /* SectionResultObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionResultObject.swift; sourceTree = "<group>"; };
 		FF61FA3023A447F5006B36C5 /* MigrationNotes_v3.0.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = MigrationNotes_v3.0.md; sourceTree = "<group>"; };
 		FF61FA3123A459AD006B36C5 /* RSDResourceImageDataObject+Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RSDResourceImageDataObject+Platform.swift"; sourceTree = "<group>"; };
 		FF639615245223C00002B1D1 /* ResultNodeSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultNodeSerializer.swift; sourceTree = "<group>"; };
@@ -2508,6 +2513,7 @@
 				FF78FC851FA7A5F500B8D42C /* RSDFileResultObject.swift */,
 				FF5C4C311F8C9DC100F311BA /* RSDResultObject.swift */,
 				FF8827E81F8DE8CD00CEFDF0 /* RSDTaskResultObject.swift */,
+				FF5D2C4C24B3A7D5000EA4E5 /* SectionResultObject.swift */,
 			);
 			name = Result;
 			sourceTree = "<group>";
@@ -2529,7 +2535,7 @@
 				FFE0BD452445436100B941BC /* MigrationNotes_v3.1.md */,
 				FFF433FD2446428B00C5F466 /* MigrationNotes_v3.2.md */,
 				FFA94E58244E35DB00A706F2 /* MigrationNotes_v3.3.md */,
-				FF518F8024AC089B003E9DAB /* ReleaseNotes_v3.4.md */,
+				FF518F8024AC089B003E9DAB /* ReleaseNotes.md */,
 				FF72B2331F6859D3004C6F15 /* Research */,
 				FF72B23E1F6859D3004C6F15 /* ResearchTests */,
 				F875575720807E2300235078 /* Research-UnitTest */,
@@ -3552,6 +3558,7 @@
 				F8EB48C4228CDBB3000A2F69 /* RSDDataLogger.swift in Sources */,
 				F8BE128A213719FB000AAB1E /* RSDCohortNavigationStep.swift in Sources */,
 				F8BE124121370A2F000AAB1E /* RSDFractionFormatter.m in Sources */,
+				FF5D2C5024B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */,
 				F8BE130421371F7B000AAB1E /* RSDMultipleComponentOptionsObject.swift in Sources */,
 				FFEA2F6F2436A878008695D6 /* KeyboardOptions.swift in Sources */,
 				FF4329AB239EF1F40027288F /* RSDFontData.swift in Sources */,
@@ -3802,6 +3809,7 @@
 				F8EB48C1228CDBB3000A2F69 /* RSDDataLogger.swift in Sources */,
 				F80CA5391FFEBF6800E89C06 /* RSDInputFieldTableItemGroup.swift in Sources */,
 				FF8B54601FCE6CB8006B6937 /* RSDImageThemeObject.swift in Sources */,
+				FF5D2C4D24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */,
 				F8904D491FF711A7002CE2EB /* RSDUnitConverter.swift in Sources */,
 				FF8B53AA1FCE6C7A006B6937 /* RSDSectionStep.swift in Sources */,
 				FFEA2F6C2436A878008695D6 /* KeyboardOptions.swift in Sources */,
@@ -4099,6 +4107,7 @@
 				F80CA53A1FFEBF6800E89C06 /* RSDInputFieldTableItemGroup.swift in Sources */,
 				F82D11182125EAF300EA1A33 /* RSDCollectionResult.swift in Sources */,
 				FF8B53BF1FCE6C7B006B6937 /* RSDSectionStep.swift in Sources */,
+				FF5D2C4E24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */,
 				FFEA2F6D2436A878008695D6 /* KeyboardOptions.swift in Sources */,
 				FFEA2F5224366C18008695D6 /* ContentNode.swift in Sources */,
 				F802F3E4204DF2B80027CB00 /* RSDUIStep.swift in Sources */,
@@ -4349,6 +4358,7 @@
 				F84A2F4721779A640079C92C /* RSDClock.swift in Sources */,
 				F8EB48C3228CDBB3000A2F69 /* RSDDataLogger.swift in Sources */,
 				FF8B549A1FCE6CEE006B6937 /* RSDPickerDataSource.swift in Sources */,
+				FF5D2C4F24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */,
 				FF8B53DD1FCE6C7B006B6937 /* RSDTextFieldOptions.swift in Sources */,
 				FF8B54661FCE6CB9006B6937 /* RSDImageThemeObject.swift in Sources */,
 				FFEA2F6E2436A878008695D6 /* KeyboardOptions.swift in Sources */,

--- a/Research/Research/Info-iOS.plist
+++ b/Research/Research/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-macOS.plist
+++ b/Research/Research/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Research/Research/Info-tvOS.plist
+++ b/Research/Research/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-watchOS.plist
+++ b/Research/Research/Info-watchOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/RSDFactory.swift
+++ b/Research/Research/RSDFactory.swift
@@ -270,7 +270,7 @@ open class RSDFactory : SerializationFactory {
     /// - parameters:
     ///     - taskResult: The task result being encoded.
     ///     - encoder: The nested encoder to encode the schema info to.
-    open func encodeSchemaInfo(from taskResult: RSDTaskResult, to encoder: Encoder) throws {
+    open func encodeSchemaInfo(from taskResult: RSDTaskRunResult, to encoder: Encoder) throws {
         if let schema = taskResult.schemaInfo, let encodableSchema = schema as? Encodable {
             try encodableSchema.encode(to: encoder)
         } else {

--- a/Research/Research/RSDResultType.swift
+++ b/Research/Research/RSDResultType.swift
@@ -55,6 +55,9 @@ public struct RSDResultType : RSDFactoryTypeRepresentable, Codable, Hashable {
     /// Defaults to creating a `RSDTaskResult`.
     public static let task: RSDResultType = "task"
     
+    /// Defaults to creating a `SectionResultObject`.
+    public static let section: RSDResultType = "section"
+    
     /// Defaults to creating a `RSDFileResult`.
     public static let file: RSDResultType = "file"
     
@@ -66,7 +69,7 @@ public struct RSDResultType : RSDFactoryTypeRepresentable, Codable, Hashable {
     
     /// List of all the standard types.
     public static func allStandardTypes() -> [RSDResultType] {
-        return [.base, .answer, .collection, .task, .file, .error, .navigation]
+        return [.base, .answer, .collection, .task, .section, .file, .error, .navigation]
     }
 }
 
@@ -93,6 +96,8 @@ public final class RSDResultSerializer : IdentifiableInterfaceSerializer, Polymo
     
     override init() {
         self.examples = [
+            RSDTaskResultObject.examples().first!,
+            SectionResultObject.examples().first!,
             RSDResultObject.examples().first!,
             AnswerResultObject.examples().first!,
             RSDCollectionResultObject.examples().first!,

--- a/Research/Research/RSDSectionStep.swift
+++ b/Research/Research/RSDSectionStep.swift
@@ -66,7 +66,7 @@ extension RSDSectionStep {
         let result = self.instantiateStepResult()
         guard let taskResult = result as? RSDTaskResult else {
             assertionFailure("Expected that a section step will return a result that conforms to RSDTaskResult protocol.")
-            return RSDTaskResultObject(identifier: identifier)
+            return SectionResultObject(identifier: identifier)
         }
         return taskResult
     }

--- a/Research/Research/RSDSectionStepObject.swift
+++ b/Research/Research/RSDSectionStepObject.swift
@@ -78,7 +78,7 @@ public struct RSDSectionStepObject: RSDSectionStep, RSDConditionalStepNavigator,
     /// Instantiate a step result that is appropriate for this step. The default for this struct is a `RSDTaskResultObject`.
     /// - returns: A result for this step.
     public func instantiateStepResult() -> RSDResult {
-        return RSDTaskResultObject(identifier: identifier)
+        return SectionResultObject(identifier: identifier)
     }
     
     /// Validate the steps in this section. The steps are valid if their identifiers are unique and if each step is valid.

--- a/Research/Research/RSDTaskMetadata.swift
+++ b/Research/Research/RSDTaskMetadata.swift
@@ -79,7 +79,6 @@ public struct RSDTaskMetadata : Codable {
     ///     - taskResult: The task result to use to pull information included in the top-level metadata.
     ///     - files: A list of files included with this metadata.
     public init(taskResult: RSDTaskResult, files: [RSDFileManifest]) {
-
         if let platformContext = currentPlatformContext {
             self.deviceInfo = platformContext.deviceInfo
             self.deviceTypeIdentifier = platformContext.deviceTypeIdentifier
@@ -94,14 +93,20 @@ public struct RSDTaskMetadata : Codable {
             self.appVersion = "Unknown"
             self.rsdFrameworkVersion = "Unknown"
         }
-        
         self.taskIdentifier = taskResult.identifier
-        self.taskRunUUID = (taskResult as? AssessmentResult)?.taskRunUUID
         self.startDate = taskResult.startDate
         self.endDate = taskResult.endDate
-        self.schemaIdentifier = taskResult.schemaInfo?.schemaIdentifier
-        self.schemaRevision = taskResult.schemaInfo?.schemaVersion
         self.files = files
+        if let runResult = taskResult as? RSDTaskRunResult {
+            self.taskRunUUID = runResult.taskRunUUID
+            self.schemaIdentifier = runResult.schemaInfo?.schemaIdentifier
+            self.schemaRevision = runResult.schemaInfo?.schemaVersion
+        }
+        else {
+            self.taskRunUUID = nil
+            self.schemaIdentifier = nil
+            self.schemaRevision = nil
+        }
     }
 }
 

--- a/Research/Research/RSDTaskMetadata.swift
+++ b/Research/Research/RSDTaskMetadata.swift
@@ -57,7 +57,7 @@ public struct RSDTaskMetadata : Codable {
     public let taskIdentifier: String
     
     /// The task run UUID.
-    public let taskRunUUID: UUID
+    public let taskRunUUID: UUID?
     
     /// The timestamp for when the task was started.
     public let startDate: Date
@@ -96,7 +96,7 @@ public struct RSDTaskMetadata : Codable {
         }
         
         self.taskIdentifier = taskResult.identifier
-        self.taskRunUUID = taskResult.taskRunUUID
+        self.taskRunUUID = (taskResult as? AssessmentResult)?.taskRunUUID
         self.startDate = taskResult.startDate
         self.endDate = taskResult.endDate
         self.schemaIdentifier = taskResult.schemaInfo?.schemaIdentifier

--- a/Research/Research/RSDTaskResult.swift
+++ b/Research/Research/RSDTaskResult.swift
@@ -37,10 +37,7 @@ import Foundation
 /// `RSDTaskResult` is a result associated with a task. This object includes a step history, task run UUID,
 /// schema identifier, and asynchronous results.
 public protocol RSDTaskResult : BranchNodeResult, RSDAnswerResultFinder {
-    
-    /// Schema info associated with this task.
-    var schemaInfo: RSDSchemaInfo? { get set }
-    
+
     /// A list of all the asynchronous results for this task. The list should include uniquely identified results.
     /// The step history is used to describe the path you took to get to where you are going, whereas
     /// the asynchronous results include any canonical results that are independent of path.
@@ -50,6 +47,9 @@ public protocol RSDTaskResult : BranchNodeResult, RSDAnswerResultFinder {
 /// The `RSDTaskRunResult` is a task result where the task run UUID can be set to allow for nested
 /// results that all use the same run UUID.
 public protocol RSDTaskRunResult : RSDTaskResult, AssessmentResult {
+    
+    /// Schema info associated with this task.
+    var schemaInfo: RSDSchemaInfo? { get set }
 }
 
 extension RSDTaskRunResult {

--- a/Research/Research/RSDTaskResult.swift
+++ b/Research/Research/RSDTaskResult.swift
@@ -38,14 +38,8 @@ import Foundation
 /// schema identifier, and asynchronous results.
 public protocol RSDTaskResult : BranchNodeResult, RSDAnswerResultFinder {
     
-    /// A unique identifier for this task run.
-    var taskRunUUID: UUID { get }
-    
     /// Schema info associated with this task.
     var schemaInfo: RSDSchemaInfo? { get set }
-    
-    /// A listing of the step history for this task or section. 
-    var stepHistory: [RSDResult] { get set }
     
     /// A list of all the asynchronous results for this task. The list should include uniquely identified results.
     /// The step history is used to describe the path you took to get to where you are going, whereas
@@ -55,10 +49,14 @@ public protocol RSDTaskResult : BranchNodeResult, RSDAnswerResultFinder {
 
 /// The `RSDTaskRunResult` is a task result where the task run UUID can be set to allow for nested
 /// results that all use the same run UUID.
-public protocol RSDTaskRunResult : RSDTaskResult {
-    
-    /// A unique identifier for this task run.
-    var taskRunUUID: UUID { get set }
+public protocol RSDTaskRunResult : RSDTaskResult, AssessmentResult {
+}
+
+extension RSDTaskRunResult {
+    public var versionString: String? {
+        guard let revision = schemaInfo?.schemaVersion else { return nil }
+        return "\(revision)"
+    }
 }
 
 extension RSDTaskResult  {

--- a/Research/Research/RSDTaskState.swift
+++ b/Research/Research/RSDTaskState.swift
@@ -86,7 +86,7 @@ open class RSDTaskState : NSObject {
     /// Create an output directory.
     public func createOutputDirectory() -> URL? {
         let tempDir = NSTemporaryDirectory()
-        let dir = self.taskResult.taskRunUUID.uuidString
+        let dir = ((self.taskResult as? AssessmentResult)?.taskRunUUID ?? UUID()).uuidString
         let path = (tempDir as NSString).appendingPathComponent(dir)
         if !FileManager.default.fileExists(atPath: path) {
             do {

--- a/Research/Research/RSDTaskViewModel.swift
+++ b/Research/Research/RSDTaskViewModel.swift
@@ -61,6 +61,10 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
     /// The task that is currently being run.
     public private(set) var task: RSDTask?
     
+    public var taskRunUUID : UUID? {
+        (self.taskResult as? AssessmentResult)?.taskRunUUID ?? (self.parent as? RSDTaskViewModel)?.taskRunUUID
+    }
+    
     /// The data manager for accessing previous runs of the task.
     public weak var dataManager: RSDDataStorageManager? {
         didSet {

--- a/Research/Research/RSDTaskViewModel.swift
+++ b/Research/Research/RSDTaskViewModel.swift
@@ -121,7 +121,9 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
         self.dataManager = (parent as? RSDHistoryPathComponent)?.dataManager
         self.previousResults = (parent.taskResult.stepHistory.last(where: { $0.identifier == identifier }) as? RSDTaskResult)?.stepHistory
         var runResult = self.taskResult as? RSDTaskRunResult
-        runResult?.taskRunUUID = parent.taskResult.taskRunUUID
+        if let uuid = (parent.taskResult as? AssessmentResult)?.taskRunUUID {
+            runResult?.taskRunUUID = uuid
+        }
         self.taskResult = runResult ?? self.taskResult
         if let _ = self.task as? RSDSectionStep {
             self.shouldShowAbbreviatedInstructions = (parentPath as? RSDTaskViewModel)?.shouldShowAbbreviatedInstructions
@@ -471,7 +473,9 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
                     newResult.asyncResults = results
                 }
                 var runResult = newResult as? RSDTaskRunResult
-                runResult?.taskRunUUID = previousResult.taskRunUUID
+                if let uuid = (previousResult as? AssessmentResult)?.taskRunUUID {
+                    runResult?.taskRunUUID = uuid
+                }
                 strongSelf.taskResult = runResult ?? newResult
             }
             else {

--- a/Research/Research/Result-KotlinModel.swift
+++ b/Research/Research/Result-KotlinModel.swift
@@ -115,7 +115,7 @@ public protocol AssessmentResult : BranchNodeResult {
     /// A unique identifier for this run of the assessment. This property is defined as readwrite
     /// to allow the controller for the task to set this on the `AssessmentResult` children
     /// included in this run.
-    var taskRunUUID: String { get set }
+    var taskRunUUID: UUID { get set }
 
     /// The `versionString` may be a semantic version, timestamp, or sequential revision integer.
     var versionString: String? { get }

--- a/Research/Research/SectionResultObject.swift
+++ b/Research/Research/SectionResultObject.swift
@@ -1,0 +1,182 @@
+//
+//  SectionResultObject.swift
+//  Research
+//
+//
+//  Copyright © 2017-2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+import JsonModel
+
+public struct SectionResultObject : RSDTaskResult, Codable {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
+        case identifier, type, startDate, endDate, stepHistory, asyncResults, nodePath
+    }
+    
+    /// The identifier associated with the task, step, or asynchronous action.
+    public let identifier: String
+    
+    /// A String that indicates the type of the result. This is used to decode the result using a `RSDFactory`.
+    public let type: RSDResultType
+    
+    /// The start date timestamp for the result.
+    public var startDate: Date = Date()
+    
+    /// The end date timestamp for the result.
+    public var endDate: Date = Date()
+    
+    /// A listing of the step history for this task or section. The listed step results should *only* include the
+    /// last result for any given step.
+    public var stepHistory: [RSDResult] = []
+    
+    /// A list of all the asynchronous results for this task. The list should include uniquely identified results.
+    public var asyncResults: [RSDResult]?
+    
+    /// The path to the current result.
+    public var nodePath: [String] = []
+    
+    /// Default initializer for this object.
+    ///
+    /// - parameters:
+    ///     - identifier: The identifier string.
+    public init(identifier: String) {
+        self.identifier = identifier
+        self.type = .section
+    }
+    
+    /// Initialize from a `Decoder`. This decoding method will use the `RSDFactory` instance associated
+    /// with the decoder to decode the `stepHistory`, `asyncResults`, and `schemaInfo`.
+    ///
+    /// - parameter decoder: The decoder to use to decode this instance.
+    /// - throws: `DecodingError`
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.identifier = try container.decode(String.self, forKey: .identifier)
+        self.type = try container.decode(RSDResultType.self, forKey: .type)
+        self.startDate = try container.decode(Date.self, forKey: .startDate)
+        self.endDate = try container.decode(Date.self, forKey: .endDate)
+        self.nodePath = try container.decodeIfPresent([String].self, forKey: .nodePath) ?? []
+        
+        let resultsContainer = try container.nestedUnkeyedContainer(forKey: .stepHistory)
+        self.stepHistory = try decoder.factory.decodePolymorphicArray(RSDResult.self, from: resultsContainer)
+        
+        if container.contains(.asyncResults) {
+            let asyncResultsContainer = try container.nestedUnkeyedContainer(forKey: .asyncResults)
+            self.asyncResults = try decoder.factory.decodePolymorphicArray(RSDResult.self, from: asyncResultsContainer)
+        }
+    }
+    
+    /// Encode the result to the given encoder.
+    /// - parameter encoder: The encoder to use to encode this instance.
+    /// - throws: `EncodingError`
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(identifier, forKey: .identifier)
+        try container.encode(type, forKey: .type)
+        try container.encode(startDate, forKey: .startDate)
+        try container.encode(endDate, forKey: .endDate)
+        try container.encode(nodePath, forKey: .nodePath)
+        
+        var nestedContainer = container.nestedUnkeyedContainer(forKey: .stepHistory)
+        for result in stepHistory {
+            let nestedEncoder = nestedContainer.superEncoder()
+            try result.encode(to: nestedEncoder)
+        }
+        
+        if let results = asyncResults {
+            var asyncContainer = container.nestedUnkeyedContainer(forKey: .asyncResults)
+            for result in results {
+                let nestedEncoder = asyncContainer.superEncoder()
+                try result.encode(to: nestedEncoder)
+            }
+        }
+    }
+}
+
+extension SectionResultObject : DocumentableStruct {
+    public static func codingKeys() -> [CodingKey] {
+        return CodingKeys.allCases
+    }
+    
+    public static func isRequired(_ codingKey: CodingKey) -> Bool {
+        guard let key = codingKey as? CodingKeys else { return false }
+        switch key {
+        case .type, .identifier, .startDate, .endDate, .stepHistory:
+            return true
+        default:
+            return false
+        }
+    }
+    
+    public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
+        guard let key = codingKey as? CodingKeys else {
+            throw DocumentableError.invalidCodingKey(codingKey, "\(codingKey) is not recognized for this class")
+        }
+        switch key {
+        case .type:
+            return .init(constValue: RSDResultType.task)
+        case .identifier:
+            return .init(propertyType: .primitive(.string))
+        case .startDate, .endDate:
+            return .init(propertyType: .format(.dateTime))
+        case .stepHistory, .asyncResults:
+            return .init(propertyType: .interfaceArray("\(RSDResult.self)"))
+        case .nodePath:
+            return .init(propertyType: .primitiveArray(.string))
+        }
+    }
+    
+    public static func examples() -> [SectionResultObject] {
+        
+        var result = SectionResultObject(identifier: "example")
+        
+        var introStepResult = RSDResultObject(identifier: "introduction")
+        introStepResult.startDate = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
+        introStepResult.endDate = introStepResult.startDate.addingTimeInterval(20)
+        var collectionResult = RSDCollectionResultObject.examples().first!
+        collectionResult.startDate = introStepResult.endDate
+        collectionResult.endDate = collectionResult.startDate.addingTimeInterval(2 * 60)
+        var conclusionStepResult = RSDResultObject(identifier: "conclusion")
+        conclusionStepResult.startDate = collectionResult.endDate
+        conclusionStepResult.endDate = conclusionStepResult.startDate.addingTimeInterval(20)
+        result.stepHistory = [introStepResult, collectionResult, conclusionStepResult]
+        
+        var fileResult = RSDFileResultObject.examples().first!
+        fileResult.startDate = collectionResult.startDate
+        fileResult.endDate = collectionResult.endDate
+        result.asyncResults = [fileResult]
+        
+        result.startDate = introStepResult.startDate
+        result.endDate = conclusionStepResult.endDate
+        
+        return [result]
+    }
+}
+

--- a/Research/ResearchLocation/Info.plist
+++ b/Research/ResearchLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 </dict>

--- a/Research/ResearchLocationTests/Info.plist
+++ b/Research/ResearchLocationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 </dict>

--- a/Research/ResearchMotion/Info.plist
+++ b/Research/ResearchMotion/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 </dict>

--- a/Research/ResearchMotionTests/Info.plist
+++ b/Research/ResearchMotionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 </dict>

--- a/Research/ResearchTests/Info-iOS.plist
+++ b/Research/ResearchTests/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 </dict>

--- a/Research/ResearchTests/Navigation Tests/TaskViewModelTests.swift
+++ b/Research/ResearchTests/Navigation Tests/TaskViewModelTests.swift
@@ -50,7 +50,7 @@ class TaskViewModelTests: XCTestCase {
         let task = TestTask(identifier: "test", stepNavigator: navigator)
         let taskInfo = TestTaskInfo(task: task)
         let taskViewModel = TestTaskViewModel(taskInfo: taskInfo)
-        let runUUID = taskViewModel.taskResult.taskRunUUID
+        let runUUID = taskViewModel.taskRunUUID ?? UUID()
         let startDate = taskViewModel.taskResult.startDate
         
         let expect = expectation(description: "Fetch Task \(taskInfo.identifier)")
@@ -73,7 +73,7 @@ class TaskViewModelTests: XCTestCase {
         
         // The task run UUID should be the same but the task result should have been replaced with a new
         // instance that has a different start date.
-        XCTAssertEqual(taskViewModel.taskResult.taskRunUUID, runUUID)
+        XCTAssertEqual(taskViewModel.taskRunUUID, runUUID)
         XCTAssertNotEqual(taskViewModel.taskResult.startDate, startDate)
     }
     
@@ -119,7 +119,7 @@ class TaskViewModelTests: XCTestCase {
         let taskInfo = TestTaskInfo(task: task)
         let taskViewModel = TestTaskViewModel(taskInfo: taskInfo)
         
-        let runUUID = taskViewModel.taskResult.taskRunUUID
+        let runUUID = taskViewModel.taskRunUUID ?? UUID()
         let startDate = taskViewModel.taskResult.startDate
         
         // Create an answer result to add to the temporary task result.
@@ -146,7 +146,7 @@ class TaskViewModelTests: XCTestCase {
         
         // The task run UUID should be the same but the task result should have been replaced with a new
         // instance that has a different start date.
-        XCTAssertEqual(taskViewModel.taskResult.taskRunUUID, runUUID)
+        XCTAssertEqual(taskViewModel.taskRunUUID, runUUID)
         XCTAssertNotEqual(taskViewModel.taskResult.startDate, startDate)
         
         // The async results should include both blu and goo

--- a/Research/ResearchUI/Info-iOS.plist
+++ b/Research/ResearchUI/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 </dict>

--- a/Research/ResearchUITests/Info.plist
+++ b/Research/ResearchUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4</string>
+	<string>3.5</string>
 	<key>CFBundleVersion</key>
 	<string>93</string>
 </dict>


### PR DESCRIPTION
@larssono @apratap 

This adds a "section" result type. 

## Future work

I left the `RSDTaskResultObject` unchanged with a type key of "task" to differentiate it from the Kotlin "assessment" result type. The different is in the keys used to define the schema identifier, assessment identifier, and version of the assessment.

Bridge 1.0 was *not* set up with a required one-to-one mapping of the schema used to populate the synapse table and the "task identifier" used to schedule a task. Typically, we will have a one-to-one mapping where these two identifiers are the same. However, due to working around some bugs in Bridge 1.0 (now fixed) and so teams like MBT can use a single synapse table with multiple versions of their assessments, this is not required.

Therefore, we need some way to differentiate between these two identifiers. In SageResearch-iOS 1.0 I did this using an interface where the `SchemaInfo` has an identifier and revision. This matched the Bridge 1.0 architecture. The result is JSON that looks like this:

```
{
    "identifier" : "foo",
    "schemaInfo" : {
        "identifier" : "bah",
        "revision" : 3
    }
}
```

Since the `taskResult.json` file was originally used only by developers to allow us to save state and restore a task that was in-flight, we changed these fields to allow for more flexibility and transparency with the Kotlin implementation. The Kotlin JSON looks like this:

```
{
    "identifier" : "bah",
    "versionString" : "3",
    "assessmentIdentifier" : "foo"
}
```

Where the "identifier" key maps to `Assessment.resultIdentifier` (which is the Schema identifier) and the "assessmentIdentifier" maps to `Assessment.identifier`. The "versionString" allows for both using both a revision counter and semantic versioning.

https://sagebionetworks.jira.com/browse/CPCF-36 Tracks this discussion and the proposed v3 task result has not yet been approved by the @larssono and @apratap.
