### PR TITLE
Add v2 task result keys to support flattened schema info

### DIFF
--- a/Research/Research/RSDTaskResult.swift
+++ b/Research/Research/RSDTaskResult.swift
@@ -57,6 +57,14 @@ extension RSDTaskRunResult {
         guard let revision = schemaInfo?.schemaVersion else { return nil }
         return "\(revision)"
     }
+    
+    public var assessmentIdentifier: String? {
+        self.identifier
+    }
+    
+    public var schemaIdentifier: String? {
+        self.schemaInfo?.schemaIdentifier
+    }
 }
 
 extension RSDTaskResult  {

--- a/Research/Research/Result-KotlinModel.swift
+++ b/Research/Research/Result-KotlinModel.swift
@@ -119,6 +119,16 @@ public protocol AssessmentResult : BranchNodeResult {
 
     /// The `versionString` may be a semantic version, timestamp, or sequential revision integer.
     var versionString: String? { get }
+    
+    ///  A unique identifier for a Assessment model associated with this result. This is explicitly
+    /// included so that the `identifier` can be associated as per the needs of the developers and
+    /// to allow for changes to the API that are not important to the researcher.
+    var assessmentIdentifier: String? { get }
+    
+    /// A unique identifier for a schema associated with this result. This is explicitly
+    /// included so that the `identifier` can be associated as per the needs of the developers and
+    /// to allow for changes to the API that are not important to the researcher.
+    var schemaIdentifier: String? { get }
 }
 
 


### PR DESCRIPTION
@larssono @apratap @philerooski 

This remains reverse-compatible to older version of the task result JSON by *adding* the keys for "assessmentIdentifier", "schemaIdentifier", and "versionString" without removing the older "schemaInfo" model object.