### PR TITLE
Collection result deprecation

### DIFF
--- a/Research/ReleaseNotes.md
+++ b/Research/ReleaseNotes.md
@@ -66,3 +66,7 @@ If you do *not* use `RSDAppDelegate` then you will need to add the following lin
 ```
 LocalizationBundle.registerDefaultBundlesIfNeeded()
 ```
+
+## Version 3.8
+
+Deprecated `RSDCollectionResult`. Use `CollectionResult` directly, instead.

--- a/Research/Research-UnitTest/Info.plist
+++ b/Research/Research-UnitTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Core/DataArchiving/RSDDataArchive.swift
+++ b/Research/Research/Core/DataArchiving/RSDDataArchive.swift
@@ -207,7 +207,7 @@ internal class TaskArchiver : NSObject {
                 }
             }
         }
-        else if let collection = result as? RSDCollectionResult {
+        else if let collection = result as? CollectionResult {
             let path = (stepPath != nil) ? "\(stepPath!)/\(collection.identifier)" : collection.identifier
             try recursiveAddFunc(sectionIdentifier, collection.identifier, path, collection.inputResults)
         }

--- a/Research/Research/Core/DataArchiving/RSDScoreBuilder.swift
+++ b/Research/Research/Core/DataArchiving/RSDScoreBuilder.swift
@@ -85,7 +85,7 @@ internal struct RecursiveScoreBuilder : RSDScoreBuilder {
         else if let taskResult = result as? RSDTaskResult {
             return try self._recursiveGetScoringData(from: taskResult)
         }
-        else if let collectionResult = result as? RSDCollectionResult {
+        else if let collectionResult = result as? CollectionResult {
             return try self._recursiveGetScoringData(from: collectionResult.inputResults)
         }
         else if let answerResult = result as? AnswerResult {

--- a/Research/Research/Core/Interfaces/Results/RSDCollectionResult.swift
+++ b/Research/Research/Core/Interfaces/Results/RSDCollectionResult.swift
@@ -36,41 +36,8 @@ import Foundation
 
 /// `RSDCollectionResult` is used include multiple results associated with a single step or async action that
 /// may have more that one result.
+@available(*, deprecated, message: "Use `CollectionResult` directly instead.")
 public protocol RSDCollectionResult : CollectionResult, RSDAnswerResultFinder {
-}
-
-extension RSDCollectionResult {
-    
-    /// Find a result within this collection.
-    /// - parameter identifier: The identifier associated with the result.
-    /// - returns: The result or `nil` if not found.
-    public func findResult(with identifier: String) -> RSDResult? {
-        return self.inputResults.first(where: { $0.identifier == identifier })
-    }
-    
-    /// Append the result to the end of the input results, replacing the previous instance with the same identifier.
-    /// - parameter result: The result to add to the input results.
-    /// - returns: The previous result or `nil` if there wasn't one.
-    @discardableResult
-    mutating public func appendInputResults(with result: RSDResult) -> RSDResult? {
-        var previousResult: RSDResult?
-        if let idx = inputResults.firstIndex(where: { $0.identifier == result.identifier }) {
-            previousResult = inputResults.remove(at: idx)
-        }
-        inputResults.append(result)
-        return previousResult
-    }
-    
-    /// Remove the result with the given identifier.
-    /// - parameter result: The result to remove from the input results.
-    /// - returns: The previous result or `nil` if there wasn't one.
-    @discardableResult
-    mutating public func removeInputResult(with identifier: String) -> RSDResult? {
-        guard let idx = inputResults.firstIndex(where: { $0.identifier == identifier }) else {
-            return nil
-        }
-        return inputResults.remove(at: idx)
-    }
 }
 
 public extension RSDCollectionResult {  // RSDAnswerResultFinder
@@ -84,11 +51,5 @@ public extension RSDCollectionResult {  // RSDAnswerResultFinder
     @available(*, deprecated, message: "Use `AnswerFinder.findAnswer` instead.")
     func findAnswerResult(with identifier:String ) -> RSDAnswerResult? {
         return self.findResult(with: identifier) as? RSDAnswerResult
-    }
-}
-
-public extension RSDCollectionResult {  // AnswerFinder
-    func findAnswer(with identifier: String) -> AnswerResult? {
-        self.findResult(with: identifier) as? AnswerResult
     }
 }

--- a/Research/Research/Core/Interfaces/Results/RSDResult.swift
+++ b/Research/Research/Core/Interfaces/Results/RSDResult.swift
@@ -70,7 +70,7 @@ extension RSDResult {
         if let answerResult = self as? AnswerResult {
             return "{\(self.identifier) : \(String(describing: answerResult.value)))}"
         }
-        else if let collectionResult = self as? RSDCollectionResult {
+        else if let collectionResult = self as? CollectionResult {
             return "{\(self.identifier) : \(collectionResult.inputResults.map ({ $0.shortDescription() }))}"
         }
         else if let taskResult = self as? RSDTaskResult {

--- a/Research/Research/Core/Interfaces/Results/Result-KotlinModel.swift
+++ b/Research/Research/Core/Interfaces/Results/Result-KotlinModel.swift
@@ -90,6 +90,37 @@ public extension CollectionResult {
     func findAnswer(with identifier: String) -> AnswerResult? {
         self.inputResults.first(where: { $0.identifier == identifier }) as? AnswerResult
     }
+    
+    /// Find a result within this collection.
+    /// - parameter identifier: The identifier associated with the result.
+    /// - returns: The result or `nil` if not found.
+    func findResult(with identifier: String) -> RSDResult? {
+        return self.inputResults.first(where: { $0.identifier == identifier })
+    }
+    
+    /// Append the result to the end of the input results, replacing the previous instance with the same identifier.
+    /// - parameter result: The result to add to the input results.
+    /// - returns: The previous result or `nil` if there wasn't one.
+    @discardableResult
+    mutating func appendInputResults(with result: RSDResult) -> RSDResult? {
+        var previousResult: RSDResult?
+        if let idx = inputResults.firstIndex(where: { $0.identifier == result.identifier }) {
+            previousResult = inputResults.remove(at: idx)
+        }
+        inputResults.append(result)
+        return previousResult
+    }
+    
+    /// Remove the result with the given identifier.
+    /// - parameter result: The result to remove from the input results.
+    /// - returns: The previous result or `nil` if there wasn't one.
+    @discardableResult
+    mutating func removeInputResult(with identifier: String) -> RSDResult? {
+        guard let idx = inputResults.firstIndex(where: { $0.identifier == identifier }) else {
+            return nil
+        }
+        return inputResults.remove(at: idx)
+    }
 }
 
 /// The `BranchNodeResult` is the result created for a given level of navigation of a node tree.

--- a/Research/Research/DataModel/Objects/Step/FormStep/AbstractFormStepObject.swift
+++ b/Research/Research/DataModel/Objects/Step/FormStep/AbstractFormStepObject.swift
@@ -52,7 +52,7 @@ open class AbstractFormStepObject : RSDUIStepObject {
     
     public private(set) var children: [ResultNode]
     
-    open func instantiateCollectionResult() -> RSDCollectionResult {
+    open func instantiateCollectionResult() -> CollectionResult {
         RSDCollectionResultObject(identifier: self.identifier)
     }
     

--- a/Research/Research/Info-iOS.plist
+++ b/Research/Research/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-macOS.plist
+++ b/Research/Research/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Research/Research/Info-tvOS.plist
+++ b/Research/Research/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-watchOS.plist
+++ b/Research/Research/Info-watchOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Recorders/RSDSampleRecorder.swift
+++ b/Research/Research/Recorders/RSDSampleRecorder.swift
@@ -355,7 +355,7 @@ open class RSDSampleRecorder : NSObject, RSDAsyncAction {
     /// to collect any results attached to this recorder, including the `ORKFileResult` that points to
     /// the logging file used to record the log samples. The property is marked as `open` to allow subclasses
     /// to point at a different implementation of the `RSDCollectionResult` protocol.
-    open private(set) var collectionResult: RSDCollectionResult
+    open private(set) var collectionResult: CollectionResult
     
     /// The clock for this recorder.
     open private(set) var clock: RSDClock = RSDClock()

--- a/Research/ResearchLocation/Info.plist
+++ b/Research/ResearchLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 </dict>

--- a/Research/ResearchLocationTests/Info.plist
+++ b/Research/ResearchLocationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 </dict>

--- a/Research/ResearchMotion/Info.plist
+++ b/Research/ResearchMotion/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 </dict>

--- a/Research/ResearchMotionTests/Info.plist
+++ b/Research/ResearchMotionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 </dict>

--- a/Research/ResearchTests/Info-iOS.plist
+++ b/Research/ResearchTests/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 </dict>

--- a/Research/ResearchUI/Info-iOS.plist
+++ b/Research/ResearchUI/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 </dict>

--- a/Research/ResearchUITests/Info.plist
+++ b/Research/ResearchUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.8</string>
 	<key>CFBundleVersion</key>
 	<string>96</string>
 </dict>


### PR DESCRIPTION
Deprecate `RSDCollectionResult`. This changes the inheritance pattern to better match the Kotlin implementation.