### PR TITLE
Changes to support removing deprecated UI form step from BridgeApp

### DIFF
--- a/Research/Research/Core/Interfaces/Steps/Questions/InputItem.swift
+++ b/Research/Research/Core/Interfaces/Steps/Questions/InputItem.swift
@@ -60,7 +60,6 @@ public protocol ChoiceInputItem : InputItem, RSDChoice {
 
 public extension ChoiceInputItem {
     var placeholder: String? { nil }
-    var fieldLabel: String? { nil }
     var isOptional: Bool { true }
 }
 

--- a/Research/Research/DataModel/Objects/Step/Question/AnswerTypeObjects.swift
+++ b/Research/Research/DataModel/Objects/Step/Question/AnswerTypeObjects.swift
@@ -171,7 +171,7 @@ public struct AnswerTypeObject : BaseAnswerType, Codable, Hashable {
     }
     
     public func decodeAnswer(from jsonValue: JsonElement?) throws -> Any? {
-        guard let value = jsonValue else { return nil }
+        guard let value = jsonValue, value != .null else { return nil }
         guard case .object(let obj) = value else {
             throw decodingError()
         }
@@ -213,7 +213,7 @@ public struct AnswerTypeString : BaseAnswerType, Codable, Hashable {
     }
     
     public func decodeAnswer(from jsonValue: JsonElement?) throws -> Any? {
-        guard let value = jsonValue else { return nil }
+        guard let value = jsonValue, value != .null else { return nil }
         guard case .string(let obj) = value else {
             throw decodingError()
         }
@@ -263,11 +263,19 @@ public struct AnswerTypeBoolean : BaseAnswerType, Codable, Hashable {
     }
     
     public func decodeAnswer(from jsonValue: JsonElement?) throws -> Any? {
-        guard let value = jsonValue else { return nil }
-        guard case .boolean(let obj) = value else {
+        guard let value = jsonValue, value != .null else { return nil }
+        switch value {
+        case .boolean(let boolValue):
+            return boolValue
+        case .integer(let intValue):
+            return intValue != 0
+        case .number(let numValue):
+            return numValue.jsonNumber()?.boolValue
+        case .string(let stringValue):
+            return (stringValue as NSString).boolValue
+        default:
             throw decodingError()
         }
-        return obj
     }
     
     public func encodeAnswer(from value: Any?) throws -> JsonElement {
@@ -309,11 +317,17 @@ public struct AnswerTypeInteger : BaseAnswerType, Codable, Hashable {
     }
     
     public func decodeAnswer(from jsonValue: JsonElement?) throws -> Any? {
-        guard let value = jsonValue else { return nil }
-        guard case .integer(let obj) = value else {
+        guard let value = jsonValue, value != .null else { return nil }
+        switch value {
+        case .integer(let intValue):
+            return intValue
+        case .number(let numValue):
+            return numValue.jsonNumber()?.intValue
+        case .string(let stringValue):
+            return (stringValue as NSString).integerValue
+        default:
             throw decodingError()
         }
-        return obj
     }
     
     public func encodeAnswer(from value: Any?) throws -> JsonElement {
@@ -362,11 +376,17 @@ extension RSDNumberAnswerType {
     }
     
     public func decodeAnswer(from jsonValue: JsonElement?) throws -> Any? {
-        guard let value = jsonValue else { return nil }
-        guard case .number(let obj) = value else {
+        guard let value = jsonValue, value != .null else { return nil }
+        switch value {
+        case .integer(let intValue):
+            return intValue
+        case .number(let numValue):
+            return numValue
+        case .string(let stringValue):
+            return (stringValue as NSString).doubleValue
+        default:
             throw decodingError()
         }
-        return obj
     }
     
     public func encodeAnswer(from value: Any?) throws -> JsonElement {

--- a/Research/Research/DataModel/Objects/Step/Question/InputItemObjects.swift
+++ b/Research/Research/DataModel/Objects/Step/Question/InputItemObjects.swift
@@ -685,8 +685,12 @@ open class ChoicePickerInputItemObject : AbstractInputItemObject, SerializableIn
     open func encodeJsonChoices(to container: UnkeyedEncodingContainer) throws {
         var nestedContainer = container
         try jsonChoices.forEach {
+            guard let encodable = $0 as? Encodable else {
+                let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "\($0) Does not conform to the Encodable protocol.")
+                throw EncodingError.invalidValue($0, context)
+            }
             let nestedEncoder = nestedContainer.superEncoder()
-            try $0.encode(to: nestedEncoder)
+            try encodable.encode(to: nestedEncoder)
         }
     }
     

--- a/Research/Research/DataModel/Objects/Step/Question/InputItemObjects.swift
+++ b/Research/Research/DataModel/Objects/Step/Question/InputItemObjects.swift
@@ -786,7 +786,7 @@ public struct SkipCheckboxInputItemObject : SkipCheckboxInputItem, Codable, Hash
     // for polymorphic decoding and does not allow for decoding using a default type. syoung 04/06/2020
     private var classType: String? = "skipCheckbox"
     
-    public let fieldLabel: String
+    public let fieldLabel: String?
     public let matchingValue: JsonElement?
     
     public var text: String? {
@@ -837,7 +837,7 @@ public struct CheckboxInputItemObject : CheckboxInputItem, SerializableInputItem
     public private(set) var inputItemType: InputItemType = .checkbox
     
     public var identifier: String?
-    public let fieldLabel: String
+    public let fieldLabel: String?
     public let detail: String?
     
     public var text: String? {

--- a/Research/Research/DataModel/Objects/Step/Question/JsonChoiceObject.swift
+++ b/Research/Research/DataModel/Objects/Step/Question/JsonChoiceObject.swift
@@ -44,7 +44,7 @@ public extension JsonComparable {
     }
 }
 
-public protocol JsonChoice : RSDChoice, JsonComparable { //, Codable {
+public protocol JsonChoice : RSDChoice, JsonComparable {
 }
 
 public extension JsonChoice {

--- a/Research/Research/DataModel/Objects/Step/Question/JsonChoiceObject.swift
+++ b/Research/Research/DataModel/Objects/Step/Question/JsonChoiceObject.swift
@@ -44,7 +44,7 @@ public extension JsonComparable {
     }
 }
 
-public protocol JsonChoice : RSDChoice, JsonComparable, Codable {
+public protocol JsonChoice : RSDChoice, JsonComparable { //, Codable {
 }
 
 public extension JsonChoice {
@@ -53,7 +53,7 @@ public extension JsonChoice {
     }
 }
 
-public struct JsonChoiceObject : JsonChoice, Hashable {
+public struct JsonChoiceObject : JsonChoice, Codable, Hashable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case matchingValue = "value", text, detail, _isExclusive = "exclusive", icon
     }

--- a/Research/Research/DataModel/Objects/Step/Question/KeyboardOptionsObject.swift
+++ b/Research/Research/DataModel/Objects/Step/Question/KeyboardOptionsObject.swift
@@ -34,7 +34,7 @@
 import Foundation
 import JsonModel
 
-public struct KeyboardOptionsObject : KeyboardOptions, Codable {
+public struct KeyboardOptionsObject : KeyboardOptions, Codable, Equatable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
         case _isSecureTextEntry = "isSecureTextEntry"
         case _autocapitalizationType = "autocapitalizationType"

--- a/Research/Research/DataModel/Objects/Step/Question/QuestionObjects.swift
+++ b/Research/Research/DataModel/Objects/Step/Question/QuestionObjects.swift
@@ -574,8 +574,12 @@ open class ChoiceQuestionStepObject : AbstractQuestionStep, ChoiceQuestion, Ques
     open func encodeJsonChoices(to container: UnkeyedEncodingContainer) throws {
         var nestedContainer = container
         try jsonChoices.forEach {
+            guard let encodable = $0 as? Encodable else {
+                let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "\($0) Does not conform to the Encodable protocol.")
+                throw EncodingError.invalidValue($0, context)
+            }
             let nestedEncoder = nestedContainer.superEncoder()
-            try $0.encode(to: nestedEncoder)
+            try encodable.encode(to: nestedEncoder)
         }
     }
 }

--- a/Research/Research/DataModel/Objects/Step/Question/TextInputValidatorObjects.swift
+++ b/Research/Research/DataModel/Objects/Step/Question/TextInputValidatorObjects.swift
@@ -35,6 +35,7 @@ import Foundation
 import JsonModel
 
 public struct PassThruValidator : TextInputValidator {
+    public init() {}
     public func answerText(for answer: Any?) -> String? {
         let value = (answer as? JsonElement).map { $0 != .null ? $0.jsonObject() : nil } ?? answer
         return value.map { "\($0)" }


### PR DESCRIPTION
Fix assorted issues discovered when migrating Bridge 1.0 Surveys to use the Question/InputItem architecture that we are moving to use in order to support Kotlin serialization.