### PR TITLE
Background noise

### DIFF
--- a/RSDCatalog/RSDCatalog.xcodeproj/project.pbxproj
+++ b/RSDCatalog/RSDCatalog.xcodeproj/project.pbxproj
@@ -53,6 +53,9 @@
 		FF432A3423A3038A0027288F /* topBackground@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FF432A3223A3038A0027288F /* topBackground@2x.png */; };
 		FF432A3723A303BB0027288F /* topMarginBackground@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FF432A3523A303BA0027288F /* topMarginBackground@2x.png */; };
 		FF432A3823A303BB0027288F /* topMarginBackground@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FF432A3623A303BB0027288F /* topMarginBackground@3x.png */; };
+		FF4A231925001F9500944009 /* Recorder_Microphone.json in Resources */ = {isa = PBXBuildFile; fileRef = FF4A231825001F9500944009 /* Recorder_Microphone.json */; };
+		FF4A231B2500263600944009 /* ResearchAudioRecorder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF4A231A2500263600944009 /* ResearchAudioRecorder.framework */; };
+		FF4A231C2500263600944009 /* ResearchAudioRecorder.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FF4A231A2500263600944009 /* ResearchAudioRecorder.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FF61FA2E23A43ADD006B36C5 /* Silver_Cat_01_Videvo.mov in Resources */ = {isa = PBXBuildFile; fileRef = FF61FA2D23A43ADD006B36C5 /* Silver_Cat_01_Videvo.mov */; };
 		FF8FC21922F3A0AF00FA6DAF /* Theme_Image.json in Resources */ = {isa = PBXBuildFile; fileRef = FF8FC21822F3A0AF00FA6DAF /* Theme_Image.json */; };
 		FFE39AEF249D55B500446A8B /* SimpleSurvey.json in Resources */ = {isa = PBXBuildFile; fileRef = FFE39AEE249D55B500446A8B /* SimpleSurvey.json */; };
@@ -83,6 +86,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				F82A4AC122960D2500BEBE3C /* ResearchLocation.framework in Embed Frameworks */,
+				FF4A231C2500263600944009 /* ResearchAudioRecorder.framework in Embed Frameworks */,
 				F891DD33228CFDE2001B2A57 /* ResearchMotion.framework in Embed Frameworks */,
 				F8D42ABA2095552100C6A4BC /* Research.framework in Embed Frameworks */,
 				F8D42ABC2095552100C6A4BC /* ResearchUI.framework in Embed Frameworks */,
@@ -141,6 +145,8 @@
 		FF432A3223A3038A0027288F /* topBackground@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "topBackground@2x.png"; sourceTree = "<group>"; };
 		FF432A3523A303BA0027288F /* topMarginBackground@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "topMarginBackground@2x.png"; sourceTree = "<group>"; };
 		FF432A3623A303BB0027288F /* topMarginBackground@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "topMarginBackground@3x.png"; sourceTree = "<group>"; };
+		FF4A231825001F9500944009 /* Recorder_Microphone.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Recorder_Microphone.json; sourceTree = "<group>"; };
+		FF4A231A2500263600944009 /* ResearchAudioRecorder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchAudioRecorder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF61FA2D23A43ADD006B36C5 /* Silver_Cat_01_Videvo.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = Silver_Cat_01_Videvo.mov; sourceTree = "<group>"; };
 		FF8FC21822F3A0AF00FA6DAF /* Theme_Image.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Theme_Image.json; sourceTree = "<group>"; };
 		FFE39AEE249D55B500446A8B /* SimpleSurvey.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SimpleSurvey.json; sourceTree = "<group>"; };
@@ -152,6 +158,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F82A4AC022960D2500BEBE3C /* ResearchLocation.framework in Frameworks */,
+				FF4A231B2500263600944009 /* ResearchAudioRecorder.framework in Frameworks */,
 				F891DD32228CFDE2001B2A57 /* ResearchMotion.framework in Frameworks */,
 				F8D42AB62095550C00C6A4BC /* Research.framework in Frameworks */,
 				F8D42AB82095550C00C6A4BC /* ResearchUI.framework in Frameworks */,
@@ -254,6 +261,7 @@
 				FF8FC21822F3A0AF00FA6DAF /* Theme_Image.json */,
 				F82A4AC222960DD400BEBE3C /* Recorder_Distance.json */,
 				F8D42A93209552EC00C6A4BC /* Recorder_Motion.json */,
+				FF4A231825001F9500944009 /* Recorder_Microphone.json */,
 				F8D42A94209552EC00C6A4BC /* FormStep_List.json */,
 				F8D42A95209552EC00C6A4BC /* FormStep_Textfield.json */,
 				F8D42A96209552EC00C6A4BC /* Theme_Color.json */,
@@ -267,6 +275,7 @@
 		F8D42AAE209554BD00C6A4BC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				FF4A231A2500263600944009 /* ResearchAudioRecorder.framework */,
 				F8D42AB52095550C00C6A4BC /* Research.framework */,
 				F8D42AB72095550C00C6A4BC /* ResearchUI.framework */,
 				F891DD31228CFDE2001B2A57 /* ResearchMotion.framework */,
@@ -413,6 +422,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FF432A2A23A3036E0027288F /* PhoneInPocket-4@2x.png in Resources */,
+				FF4A231925001F9500944009 /* Recorder_Microphone.json in Resources */,
 				FF432A2D23A3036E0027288F /* PhoneInPocket-4@3x.png in Resources */,
 				FF432A3423A3038A0027288F /* topBackground@2x.png in Resources */,
 				FF432A3023A3036E0027288F /* PhoneInPocket-3@3x.png in Resources */,

--- a/RSDCatalog/RSDCatalog/CatalogFactory.swift
+++ b/RSDCatalog/RSDCatalog/CatalogFactory.swift
@@ -34,6 +34,7 @@
 import Foundation
 import Research
 import ResearchMotion
+import ResearchAudioRecorder
 import JsonModel
 
 /// Stub out a factory for this application. Any factory overrides that are used by the catalog
@@ -45,6 +46,7 @@ class CatalogFactory : RSDFactory {
     required init() {
         super.init()
         self.taskSerializer.add(RSDMotionTaskObject(identifier: "motion", steps: []))
+        self.taskSerializer.add(AudioRecorderTaskObject(identifier: "microphone", steps: []))
     }
     
     func decodeTaskGroups(from jsonData: Data) throws -> [RSDTaskGroup] {

--- a/RSDCatalog/RSDCatalog/FileResultViewController.swift
+++ b/RSDCatalog/RSDCatalog/FileResultViewController.swift
@@ -67,12 +67,12 @@ class FileResultViewController: UIViewController {
         }
 
         do {
-            if url.pathExtension == "jpeg" {
+            if url.pathExtension == "jpeg" || url.pathExtension == "png" {
                 self.imageView.isHidden = false
                 let data = try Data(contentsOf: url)
                 self.imageView.image = UIImage(data: data)
             }
-            else if url.pathExtension == "mov" {
+            else if url.pathExtension == "mov" || url.pathExtension == "mp4" {
                 let player = AVPlayer(url: url)
                 let playerController = AVPlayerViewController()
                 playerController.player = player

--- a/RSDCatalog/RSDCatalog/Info.plist
+++ b/RSDCatalog/RSDCatalog/Info.plist
@@ -20,8 +20,6 @@
 	<string>94</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSCameraUsageDescription</key>
-	<string>This app uses the camera to take pictures as an example of using the Image Picker.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>This app uses the GPS sensor to measure relative distance travelled.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
@@ -29,11 +27,9 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app uses the GPS sensor to measure relative distance travelled.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>This app uses the camera to take videos as an example of using the Image Picker.</string>
+	<string>This app uses the microphone to record background audio.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>This app uses the motion sensors to record motion while shaking the phone.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>This app selects pictures from the photo library as an example of using the Image Picker.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/RSDCatalog/RSDCatalog/Info.plist
+++ b/RSDCatalog/RSDCatalog/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>94</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/RSDCatalog/RSDCatalog/JSON Files/Recorder_Microphone.json
+++ b/RSDCatalog/RSDCatalog/JSON Files/Recorder_Microphone.json
@@ -42,7 +42,8 @@
                                                   "identifier"              : "microphone",
                                                   "type"                    : "microphone",
                                                   "startStepIdentifier"     : "countdown",
-                                                  "requiresBackgroundAudio" : true
+                                                  "requiresBackgroundAudio" : true,
+                                                  "saveAudioFile"           : true
                                                   }
                                                   ],
                            "steps"          : [

--- a/RSDCatalog/RSDCatalog/JSON Files/Recorder_Microphone.json
+++ b/RSDCatalog/RSDCatalog/JSON Files/Recorder_Microphone.json
@@ -1,0 +1,103 @@
+{
+    "identifier"        : "microphone",
+    "type": "audioRecorderTask",
+    "resultIdentifier": "Audio Recorder",
+    "versionString": "1",
+    "shouldHideActions" : ["goBackward", "skip"],
+    "steps"             : [
+                            {
+                                "identifier": "introduction",
+                                "type": "overview",
+                                "title": "Audio and Motion Recorder",
+                                "detail": "This activity shows an example of recording audio and motion in the same task.",
+                                "image": {
+                                    "type": "fetchable",
+                                    "imageName": "HoldPhone",
+                                    "placementType": "topBackground"
+                                },
+                                "actions": {
+                                    "goForward": {
+                                        "type": "default",
+                                        "buttonTitle": "Get started"
+                                    },
+                                    "learnMore": {
+                                        "type": "videoView",
+                                        "buttonTitle": "Learn more",
+                                        "url": "Silver_Cat_01_Videvo.mov"
+                                    }
+                                }
+                            },
+                           {
+                           "identifier"     : "shaker",
+                           "type"           : "section",
+                           "asyncActions"      : [
+                                                  {
+                                                  "identifier"              : "motion",
+                                                  "type"                    : "motion",
+                                                  "startStepIdentifier"     : "countdown",
+                                                  "requiresBackgroundAudio" : true,
+                                                  "recorderTypes"           : ["gyro"]
+                                                  },
+                                                  {
+                                                  "identifier"              : "microphone",
+                                                  "type"                    : "microphone",
+                                                  "startStepIdentifier"     : "countdown",
+                                                  "requiresBackgroundAudio" : true
+                                                  }
+                                                  ],
+                           "steps"          : [
+                                               {
+                                               "identifier"   : "instruction",
+                                               "type"         : "instruction",
+                                               "title"        : "Hold your phone",
+                                               "detail"         : "After the countdown, shake your phone while singing. This will record the raw gyro data and audio.",
+                                               "image": {
+                                                   "type": "fetchable",
+                                                   "imageName": "HoldPhone",
+                                                   "placementType": "topBackground"
+                                               }
+                                               },
+                                               {
+                                               "identifier"     : "countdown",
+                                               "type"           : "countdown",
+                                               "commands"       : ["speakWarningOnPause"]
+                                               },
+                                               {
+                                               "identifier"         : "motion",
+                                               "type"               : "active",
+                                               "duration"           : 30,
+                                               "title"              : "Shake your phone",
+                                               "image": {
+                                                   "type": "fetchable",
+                                                   "imageName": "HoldPhone",
+                                                   "placementType": "fullsizeBackground"
+                                               },
+                                               "commands"           : ["startTimerAutomatically", "shouldDisableIdleTimer", "vibrate",
+                                                                       "playSound"],
+                                               "actions":{
+                                                   "skip":{
+                                                       "type":"navigation",
+                                                       "skipToIdentifier":"countdown",
+                                                       "buttonTitle": "Restart test"
+                                                   },
+                                                   "reviewInstructions":{
+                                                       "type":"navigation",
+                                                       "skipToIdentifier": "instruction",
+                                                       "buttonTitle": "Review instructions"
+                                                   }
+                                               },
+                                               "spokenInstructions" : { "start": "Start shaking your phone",
+                                                                        "halfway": "Halfway there. Keep shaking!",
+                                                                        "countdown": "10",
+                                                                        "end": "You're done!"}
+                                               }
+                                               ]
+                           },
+                           {
+                           "identifier"   : "completion",
+                           "type"         : "completion",
+                           "title"        : "Great Job!",
+                           "detail"         : "You have completed this task."
+                           }
+                           ]
+}

--- a/RSDCatalog/RSDCatalog/JSON Files/TaskGroups.json
+++ b/RSDCatalog/RSDCatalog/JSON Files/TaskGroups.json
@@ -58,7 +58,15 @@
                 "detail": "This is an example task for recording motion sensor data using the RSDMotionRecorder. This task also includes using the voice synthesizer to include spoken instructions.",
                 "icon": "activityIcon",
                 "taskTransformer" : { "resourceName": "Recorder_Motion" }
-                }]
+                },
+                  {
+                 "identifier": "microphone",
+                 "title": "Audio and Motion Recorder",
+                 "subtitle": "Activity for recording audio and motion sensor data.",
+                 "detail": "This is an example task for recording audio and motion sensor data using the RSDMotionRecorder and AudioRecorder. This task also includes using the voice synthesizer to include spoken instructions.",
+                 "icon": "activityIcon",
+                 "taskTransformer" : { "resourceName": "Recorder_Microphone" }
+                 }]
  },
  {
  "identifier": "colorExamples",

--- a/RSDCatalog/RSDCatalogTests/Info.plist
+++ b/RSDCatalog/RSDCatalogTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>94</string>
 </dict>

--- a/RSDCatalog/RSDCatalogUITests/Info.plist
+++ b/RSDCatalog/RSDCatalogUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>94</string>
 </dict>

--- a/Research/ReleaseNotes.md
+++ b/Research/ReleaseNotes.md
@@ -74,3 +74,7 @@ Deprecated `RSDCollectionResult`. Use `CollectionResult` directly, instead.
 ## Version 3.9
 
 Assorted minor fixes to better support using the newer protocols and objects from other frameworks.
+
+## Version 3.10
+
+Added `ResearchAudioRecorder` framework for recording audio and full scale decibel level.

--- a/Research/Research-UnitTest/Info.plist
+++ b/Research/Research-UnitTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research.xcodeproj/project.pbxproj
+++ b/Research/Research.xcodeproj/project.pbxproj
@@ -800,6 +800,18 @@
 		FF432A0E23A05BA20027288F /* Geometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF432A0B23A05BA20027288F /* Geometry.swift */; };
 		FF432A0F23A05BA20027288F /* Geometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF432A0B23A05BA20027288F /* Geometry.swift */; };
 		FF432A1C23A2FBE90027288F /* ThemeImageViewOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF432A1B23A2FBE80027288F /* ThemeImageViewOwner.swift */; };
+		FF4A22E624FDB20200944009 /* ResearchAudioRecorder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF4A22DD24FDB20200944009 /* ResearchAudioRecorder.framework */; };
+		FF4A22EB24FDB20200944009 /* ResearchAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A22EA24FDB20200944009 /* ResearchAudioRecorderTests.swift */; };
+		FF4A22ED24FDB20200944009 /* ResearchAudioRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = FF4A22DF24FDB20200944009 /* ResearchAudioRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF4A22F624FEB6E900944009 /* AudioRecorderAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A22F524FEB6E900944009 /* AudioRecorderAuthorization.swift */; };
+		FF4A22F724FEB82A00944009 /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF8B53141FCE678E006B6937 /* Research.framework */; platformFilter = ios; };
+		FF4A22FD24FEBB3C00944009 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A22FC24FEBB3C00944009 /* AudioRecorder.swift */; };
+		FF4A22FF24FEBC5E00944009 /* AudioRecorderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A22FE24FEBC5E00944009 /* AudioRecorderConfiguration.swift */; };
+		FF4A230024FEBC5E00944009 /* AudioRecorderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A22FE24FEBC5E00944009 /* AudioRecorderConfiguration.swift */; };
+		FF4A230124FEBC5E00944009 /* AudioRecorderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A22FE24FEBC5E00944009 /* AudioRecorderConfiguration.swift */; };
+		FF4A230224FEBC5E00944009 /* AudioRecorderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A22FE24FEBC5E00944009 /* AudioRecorderConfiguration.swift */; };
+		FF4A230924FEC47600944009 /* AudioRecorderAudioSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A230424FEC47600944009 /* AudioRecorderAudioSessionController.swift */; };
+		FF4A230B24FEC4FF00944009 /* AudioRecorderTaskObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A230A24FEC4FF00944009 /* AudioRecorderTaskObject.swift */; };
 		FF5D2C4D24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5D2C4C24B3A7D5000EA4E5 /* SectionResultObject.swift */; };
 		FF5D2C4E24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5D2C4C24B3A7D5000EA4E5 /* SectionResultObject.swift */; };
 		FF5D2C4F24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5D2C4C24B3A7D5000EA4E5 /* SectionResultObject.swift */; };
@@ -1223,6 +1235,20 @@
 			remoteGlobalIDString = F891DD12228CFCD3001B2A57;
 			remoteInfo = ResearchMotion;
 		};
+		FF4A22E724FDB20200944009 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FF72B2281F6859D2004C6F15 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FF4A22DC24FDB20200944009;
+			remoteInfo = ResearchAudioRecorder;
+		};
+		FF4A22F924FEB82A00944009 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FF72B2281F6859D2004C6F15 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FF8B53131FCE678E006B6937;
+			remoteInfo = "Research (iOS)";
+		};
 		FF8B531E1FCE678E006B6937 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FF72B2281F6859D2004C6F15 /* Project object */;
@@ -1534,6 +1560,17 @@
 		FF4329E123A044A20027288F /* RSDResourceImageDataObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDResourceImageDataObject.swift; sourceTree = "<group>"; };
 		FF432A0B23A05BA20027288F /* Geometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geometry.swift; sourceTree = "<group>"; };
 		FF432A1B23A2FBE80027288F /* ThemeImageViewOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeImageViewOwner.swift; sourceTree = "<group>"; };
+		FF4A22DD24FDB20200944009 /* ResearchAudioRecorder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ResearchAudioRecorder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FF4A22DF24FDB20200944009 /* ResearchAudioRecorder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ResearchAudioRecorder.h; sourceTree = "<group>"; };
+		FF4A22E024FDB20200944009 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FF4A22E524FDB20200944009 /* ResearchAudioRecorderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ResearchAudioRecorderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FF4A22EA24FDB20200944009 /* ResearchAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResearchAudioRecorderTests.swift; sourceTree = "<group>"; };
+		FF4A22EC24FDB20200944009 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FF4A22F524FEB6E900944009 /* AudioRecorderAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderAuthorization.swift; sourceTree = "<group>"; };
+		FF4A22FC24FEBB3C00944009 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
+		FF4A22FE24FEBC5E00944009 /* AudioRecorderConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderConfiguration.swift; sourceTree = "<group>"; };
+		FF4A230424FEC47600944009 /* AudioRecorderAudioSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderAudioSessionController.swift; sourceTree = "<group>"; };
+		FF4A230A24FEC4FF00944009 /* AudioRecorderTaskObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderTaskObject.swift; sourceTree = "<group>"; };
 		FF518F8024AC089B003E9DAB /* ReleaseNotes.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ReleaseNotes.md; sourceTree = "<group>"; };
 		FF580BF31F7E3764009B3EE9 /* RSDActiveUIStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDActiveUIStepObject.swift; sourceTree = "<group>"; };
 		FF580BF51F7ED80B009B3EE9 /* Dictionary+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Utilities.swift"; sourceTree = "<group>"; };
@@ -1728,6 +1765,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				FFF434062446448700C5F466 /* JsonModel in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF4A22DA24FDB20200944009 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF4A22F724FEB82A00944009 /* Research.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF4A22E224FDB20200944009 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF4A22E624FDB20200944009 /* ResearchAudioRecorder.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2492,6 +2545,36 @@
 			path = ThemedUI;
 			sourceTree = "<group>";
 		};
+		FF4A22DE24FDB20200944009 /* ResearchAudioRecorder */ = {
+			isa = PBXGroup;
+			children = (
+				FF4A22DF24FDB20200944009 /* ResearchAudioRecorder.h */,
+				FF4A22E024FDB20200944009 /* Info.plist */,
+				FF4A22F424FEB6A500944009 /* Audio Recorder */,
+			);
+			path = ResearchAudioRecorder;
+			sourceTree = "<group>";
+		};
+		FF4A22E924FDB20200944009 /* ResearchAudioRecorderTests */ = {
+			isa = PBXGroup;
+			children = (
+				FF4A22EA24FDB20200944009 /* ResearchAudioRecorderTests.swift */,
+				FF4A22EC24FDB20200944009 /* Info.plist */,
+			);
+			path = ResearchAudioRecorderTests;
+			sourceTree = "<group>";
+		};
+		FF4A22F424FEB6A500944009 /* Audio Recorder */ = {
+			isa = PBXGroup;
+			children = (
+				FF4A22F524FEB6E900944009 /* AudioRecorderAuthorization.swift */,
+				FF4A22FC24FEBB3C00944009 /* AudioRecorder.swift */,
+				FF4A230424FEC47600944009 /* AudioRecorderAudioSessionController.swift */,
+				FF4A230A24FEC4FF00944009 /* AudioRecorderTaskObject.swift */,
+			);
+			path = "Audio Recorder";
+			sourceTree = "<group>";
+		};
 		FF5C4C301F8C9D9600F311BA /* Result */ = {
 			isa = PBXGroup;
 			children = (
@@ -2527,8 +2610,8 @@
 				FFA94E58244E35DB00A706F2 /* MigrationNotes_v3.3.md */,
 				FF518F8024AC089B003E9DAB /* ReleaseNotes.md */,
 				FF72B2331F6859D3004C6F15 /* Research */,
-				FF72B23E1F6859D3004C6F15 /* ResearchTests */,
 				F875575720807E2300235078 /* Research-UnitTest */,
+				FF72B23E1F6859D3004C6F15 /* ResearchTests */,
 				F87061A1227390110056F70E /* ResearchUI */,
 				F87061AC227390120056F70E /* ResearchUITests */,
 				F891DD14228CFCD3001B2A57 /* ResearchMotion */,
@@ -2536,6 +2619,8 @@
 				F82A4AA122960BF700BEBE3C /* ResearchLocation */,
 				F82A4AAC22960BF700BEBE3C /* ResearchLocationTests */,
 				F891DCF0228CF9D0001B2A57 /* ResearchToolbox */,
+				FF4A22DE24FDB20200944009 /* ResearchAudioRecorder */,
+				FF4A22E924FDB20200944009 /* ResearchAudioRecorderTests */,
 				FF72B2321F6859D3004C6F15 /* Products */,
 				F875575F20807E8B00235078 /* Frameworks */,
 			);
@@ -2556,6 +2641,8 @@
 				F891DD1B228CFCD3001B2A57 /* ResearchMotionTests.xctest */,
 				F82A4AA022960BF700BEBE3C /* ResearchLocation.framework */,
 				F82A4AA822960BF700BEBE3C /* ResearchLocationTests.xctest */,
+				FF4A22DD24FDB20200944009 /* ResearchAudioRecorder.framework */,
+				FF4A22E524FDB20200944009 /* ResearchAudioRecorderTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2704,6 +2791,7 @@
 				F8B17860202E22CC00B62416 /* RSDStandardAsyncActionConfiguration.swift */,
 				F810CF35202E2811009C49C9 /* RSDMotionRecorderConfiguration.swift */,
 				F8B17854202E1AB100B62416 /* RSDDistanceRecorderConfiguration.swift */,
+				FF4A22FE24FEBC5E00944009 /* AudioRecorderConfiguration.swift */,
 			);
 			name = AsyncAction;
 			path = AsyncActions;
@@ -2920,6 +3008,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FF4A22D824FDB20200944009 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF4A22ED24FDB20200944009 /* ResearchAudioRecorder.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF8B53111FCE678E006B6937 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -3115,6 +3211,43 @@
 			productReference = F8BE123521370931000AAB1E /* Research.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		FF4A22DC24FDB20200944009 /* ResearchAudioRecorder */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FF4A22F224FDB20200944009 /* Build configuration list for PBXNativeTarget "ResearchAudioRecorder" */;
+			buildPhases = (
+				FF4A22D824FDB20200944009 /* Headers */,
+				FF4A22D924FDB20200944009 /* Sources */,
+				FF4A22DA24FDB20200944009 /* Frameworks */,
+				FF4A22DB24FDB20200944009 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FF4A22FA24FEB82A00944009 /* PBXTargetDependency */,
+			);
+			name = ResearchAudioRecorder;
+			productName = ResearchAudioRecorder;
+			productReference = FF4A22DD24FDB20200944009 /* ResearchAudioRecorder.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		FF4A22E424FDB20200944009 /* ResearchAudioRecorderTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FF4A22F324FDB20200944009 /* Build configuration list for PBXNativeTarget "ResearchAudioRecorderTests" */;
+			buildPhases = (
+				FF4A22E124FDB20200944009 /* Sources */,
+				FF4A22E224FDB20200944009 /* Frameworks */,
+				FF4A22E324FDB20200944009 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FF4A22E824FDB20200944009 /* PBXTargetDependency */,
+			);
+			name = ResearchAudioRecorderTests;
+			productName = ResearchAudioRecorderTests;
+			productReference = FF4A22E524FDB20200944009 /* ResearchAudioRecorderTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		FF8B53131FCE678E006B6937 /* Research (iOS) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF8B53291FCE678E006B6937 /* Build configuration list for PBXNativeTarget "Research (iOS)" */;
@@ -3202,7 +3335,7 @@
 		FF72B2281F6859D2004C6F15 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1120;
+				LastSwiftUpdateCheck = 1160;
 				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = "Sage Bionetworks";
 				TargetAttributes = {
@@ -3243,6 +3376,13 @@
 						CreatedOnToolsVersion = 9.4.1;
 						LastSwiftMigration = 1030;
 						ProvisioningStyle = Automatic;
+					};
+					FF4A22DC24FDB20200944009 = {
+						CreatedOnToolsVersion = 11.6;
+						LastSwiftMigration = 1160;
+					};
+					FF4A22E424FDB20200944009 = {
+						CreatedOnToolsVersion = 11.6;
 					};
 					FF8B53131FCE678E006B6937 = {
 						CreatedOnToolsVersion = 9.1;
@@ -3295,6 +3435,8 @@
 				F891DD1A228CFCD3001B2A57 /* ResearchMotionTests */,
 				F82A4A9F22960BF700BEBE3C /* ResearchLocation */,
 				F82A4AA722960BF700BEBE3C /* ResearchLocationTests */,
+				FF4A22DC24FDB20200944009 /* ResearchAudioRecorder */,
+				FF4A22E424FDB20200944009 /* ResearchAudioRecorderTests */,
 			);
 		};
 /* End PBXProject section */
@@ -3376,6 +3518,20 @@
 				FF287A4523A3701100677D62 /* lato_italic.ttf in Resources */,
 				FF287A8123A3701100677D62 /* lato_bold.ttf in Resources */,
 				FF287A7D23A3701100677D62 /* lato_regular.ttf in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF4A22DB24FDB20200944009 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF4A22E324FDB20200944009 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3596,6 +3752,7 @@
 				F8BE124121370A2F000AAB1E /* RSDFractionFormatter.m in Sources */,
 				FF5D2C5024B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */,
 				F8BE130421371F7B000AAB1E /* RSDMultipleComponentOptionsObject.swift in Sources */,
+				FF4A230224FEBC5E00944009 /* AudioRecorderConfiguration.swift in Sources */,
 				FFEA2F6F2436A878008695D6 /* KeyboardOptions.swift in Sources */,
 				FF4329AB239EF1F40027288F /* RSDFontData.swift in Sources */,
 				FFEA2F5424366C18008695D6 /* ContentNode.swift in Sources */,
@@ -3804,6 +3961,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FF4A22D924FDB20200944009 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF4A230B24FEC4FF00944009 /* AudioRecorderTaskObject.swift in Sources */,
+				FF4A22FD24FEBB3C00944009 /* AudioRecorder.swift in Sources */,
+				FF4A230924FEC47600944009 /* AudioRecorderAudioSessionController.swift in Sources */,
+				FF4A22F624FEB6E900944009 /* AudioRecorderAuthorization.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF4A22E124FDB20200944009 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF4A22EB24FDB20200944009 /* ResearchAudioRecorderTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF8B530F1FCE678E006B6937 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3849,6 +4025,7 @@
 				FF8B54601FCE6CB8006B6937 /* RSDImageThemeObject.swift in Sources */,
 				FF5D2C4D24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */,
 				F8904D491FF711A7002CE2EB /* RSDUnitConverter.swift in Sources */,
+				FF4A22FF24FEBC5E00944009 /* AudioRecorderConfiguration.swift in Sources */,
 				FF8B53AA1FCE6C7A006B6937 /* RSDSectionStep.swift in Sources */,
 				FFEA2F6C2436A878008695D6 /* KeyboardOptions.swift in Sources */,
 				F80CA51F1FFEB04B00E89C06 /* RSDChoiceOptionsObject.swift in Sources */,
@@ -4149,6 +4326,7 @@
 				FF8B53BF1FCE6C7B006B6937 /* RSDSectionStep.swift in Sources */,
 				FF5D2C4E24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */,
 				FFEA2F6D2436A878008695D6 /* KeyboardOptions.swift in Sources */,
+				FF4A230024FEBC5E00944009 /* AudioRecorderConfiguration.swift in Sources */,
 				FFEA2F5224366C18008695D6 /* ContentNode.swift in Sources */,
 				F802F3E4204DF2B80027CB00 /* RSDUIStep.swift in Sources */,
 				F8904D4A1FF711A7002CE2EB /* RSDUnitConverter.swift in Sources */,
@@ -4402,6 +4580,7 @@
 				FF8B549A1FCE6CEE006B6937 /* RSDPickerDataSource.swift in Sources */,
 				FF5D2C4F24B3A7D5000EA4E5 /* SectionResultObject.swift in Sources */,
 				FF8B53DD1FCE6C7B006B6937 /* RSDTextFieldOptions.swift in Sources */,
+				FF4A230124FEBC5E00944009 /* AudioRecorderConfiguration.swift in Sources */,
 				FF8B54661FCE6CB9006B6937 /* RSDImageThemeObject.swift in Sources */,
 				FFEA2F6E2436A878008695D6 /* KeyboardOptions.swift in Sources */,
 				F8BE10C32135E19B000AAB1E /* RSDValidationError.swift in Sources */,
@@ -4627,6 +4806,17 @@
 			isa = PBXTargetDependency;
 			target = F891DD12228CFCD3001B2A57 /* ResearchMotion */;
 			targetProxy = F891DD1D228CFCD4001B2A57 /* PBXContainerItemProxy */;
+		};
+		FF4A22E824FDB20200944009 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FF4A22DC24FDB20200944009 /* ResearchAudioRecorder */;
+			targetProxy = FF4A22E724FDB20200944009 /* PBXContainerItemProxy */;
+		};
+		FF4A22FA24FEB82A00944009 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = FF8B53131FCE678E006B6937 /* Research (iOS) */;
+			targetProxy = FF4A22F924FEB82A00944009 /* PBXContainerItemProxy */;
 		};
 		FF8B531F1FCE678E006B6937 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5143,6 +5333,123 @@
 			};
 			name = Release;
 		};
+		FF4A22EE24FDB20200944009 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = KA9Z8R6M6K;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ResearchAudioRecorder/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.sagebionetworks.ResearchAudioRecorder;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FF4A22EF24FDB20200944009 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = KA9Z8R6M6K;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ResearchAudioRecorder/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.sagebionetworks.ResearchAudioRecorder;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		FF4A22F024FDB20200944009 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KA9Z8R6M6K;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ResearchAudioRecorderTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.sagebionetworks.ResearchAudioRecorderTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FF4A22F124FDB20200944009 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KA9Z8R6M6K;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ResearchAudioRecorderTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.sagebionetworks.ResearchAudioRecorderTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		FF72B2431F6859D3004C6F15 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5588,6 +5895,24 @@
 			buildConfigurations = (
 				F8BE123B21370931000AAB1E /* Debug */,
 				F8BE123C21370931000AAB1E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FF4A22F224FDB20200944009 /* Build configuration list for PBXNativeTarget "ResearchAudioRecorder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FF4A22EE24FDB20200944009 /* Debug */,
+				FF4A22EF24FDB20200944009 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FF4A22F324FDB20200944009 /* Build configuration list for PBXNativeTarget "ResearchAudioRecorderTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FF4A22F024FDB20200944009 /* Debug */,
+				FF4A22F124FDB20200944009 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Research/Research.xcodeproj/xcshareddata/xcschemes/ResearchAudioRecorder-iOS.xcscheme
+++ b/Research/Research.xcodeproj/xcshareddata/xcschemes/ResearchAudioRecorder-iOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FF4A22DC24FDB20200944009"
+               BuildableName = "ResearchAudioRecorder.framework"
+               BlueprintName = "ResearchAudioRecorder"
+               ReferencedContainer = "container:Research.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FF4A22DC24FDB20200944009"
+            BuildableName = "ResearchAudioRecorder.framework"
+            BlueprintName = "ResearchAudioRecorder"
+            ReferencedContainer = "container:Research.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Research/Research/Core/DataArchiving/RSDFileResultUtility.swift
+++ b/Research/Research/Core/DataArchiving/RSDFileResultUtility.swift
@@ -104,7 +104,6 @@ public class RSDFileResultUtility {
             }
         }
         
-        assertionFailure("A file already exists at \(filename).")
         let uuidCode = UUID().uuidString.prefix(4)
         return URL(fileURLWithPath: "\(filename)-\(uuidCode).\(ext)", relativeTo: outputDirectory)
     }

--- a/Research/Research/DataModel/Objects/AsyncActions/AudioRecorderConfiguration.swift
+++ b/Research/Research/DataModel/Objects/AsyncActions/AudioRecorderConfiguration.swift
@@ -53,7 +53,7 @@ import JsonModel
 /// ```
 public struct AudioRecorderConfiguration : RSDRecorderConfiguration, Codable {
     private enum CodingKeys : String, CodingKey, CaseIterable {
-        case identifier, asyncActionType = "type", startStepIdentifier, stopStepIdentifier, _requiresBackgroundAudio = "requiresBackgroundAudio"
+        case identifier, asyncActionType = "type", startStepIdentifier, stopStepIdentifier, _requiresBackgroundAudio = "requiresBackgroundAudio", _saveAudioFile = "saveAudioFile"
     }
     
     /// A short string that uniquely identifies the asynchronous action within the task. If started
@@ -85,17 +85,28 @@ public struct AudioRecorderConfiguration : RSDRecorderConfiguration, Codable {
     }
     private let _requiresBackgroundAudio: Bool?
     
+    /// Should the audio recording be saved? Default = `false`.
+    ///
+    /// If `true` then the audio file used to measure meter levels is saved with the results.
+    /// Otherwise, the audio file recorded is assumed to be a temporary file and should be deleted
+    /// when the recording stops.
+    public var saveAudioFile: Bool {
+        return _saveAudioFile ?? false
+    }
+    private let _saveAudioFile: Bool?
+    
     /// Default initializer.
     /// - parameters:
     ///     - identifier: The configuration identifier.
     ///     - motionStepIdentifier: Optional identifier for the step that records distance travelled.
     ///     - startStepIdentifier: An identifier marking the step to start the action. Default = `nil`.
     ///     - stopStepIdentifier: An identifier marking the step to stop the action.  Default = `nil`.
-    public init(identifier: String, startStepIdentifier: String? = nil, stopStepIdentifier: String? = nil, requiresBackgroundAudio: Bool = false) {
+    public init(identifier: String, startStepIdentifier: String? = nil, stopStepIdentifier: String? = nil, requiresBackgroundAudio: Bool = false, saveAudioFile: Bool? = nil) {
         self.identifier = identifier
         self.startStepIdentifier = startStepIdentifier
         self.stopStepIdentifier = stopStepIdentifier
         self._requiresBackgroundAudio = requiresBackgroundAudio
+        self._saveAudioFile = saveAudioFile
     }
     
     /// Returns `location` and `motion` on iOS. Returns an empty set on platforms that do not
@@ -137,13 +148,13 @@ extension AudioRecorderConfiguration : DocumentableStruct {
             return .init(propertyType: .primitive(.string))
         case .startStepIdentifier, .stopStepIdentifier:
             return .init(propertyType: .primitive(.string))
-        case ._requiresBackgroundAudio:
+        case ._requiresBackgroundAudio, ._saveAudioFile:
             return .init(propertyType: .primitive(.boolean))
         }
     }
     
     public static func examples() -> [AudioRecorderConfiguration] {
-        let example = AudioRecorderConfiguration(identifier: "microphone", startStepIdentifier: "countdown", stopStepIdentifier: "rest", requiresBackgroundAudio: true)
+        let example = AudioRecorderConfiguration(identifier: "microphone", startStepIdentifier: "countdown", stopStepIdentifier: "rest", requiresBackgroundAudio: true, saveAudioFile: true)
         return [example]
     }
 }

--- a/Research/Research/DataModel/Objects/AsyncActions/AudioRecorderConfiguration.swift
+++ b/Research/Research/DataModel/Objects/AsyncActions/AudioRecorderConfiguration.swift
@@ -1,0 +1,149 @@
+//
+//  AudioRecorderConfiguration.swift
+//  Research
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+
+import Foundation
+import JsonModel
+
+/// The default configuration to use for a `AudioRecorder`.
+///
+/// - example:
+///
+/// ```
+///     // Example json for a codable configuration.
+///        let json = """
+///             {
+///                "identifier": "foo",
+///                "type": "microphone",
+///                "startStepIdentifier": "countdown",
+///                "stopStepIdentifier": "rest",
+///                "requiresBackgroundAudio": true,
+///            }
+///            """.data(using: .utf8)! // our data in native (JSON) format
+/// ```
+public struct AudioRecorderConfiguration : RSDRecorderConfiguration, Codable {
+    private enum CodingKeys : String, CodingKey, CaseIterable {
+        case identifier, asyncActionType = "type", startStepIdentifier, stopStepIdentifier, _requiresBackgroundAudio = "requiresBackgroundAudio"
+    }
+    
+    /// A short string that uniquely identifies the asynchronous action within the task. If started
+    /// asynchronously, then the identifier maps to a result stored in `RSDTaskResult.asyncResults`.
+    public let identifier: String
+    
+    /// The standard permission type associated with this configuration.
+    public private(set) var asyncActionType: RSDAsyncActionType = .microphone
+    
+    /// An identifier marking the step to start the action. If `nil`, then the action will be started when
+    /// the task is started.
+    public let startStepIdentifier: String?
+    
+    /// An identifier marking the step to stop the action. If `nil`, then the action will be started when
+    /// the task is started.
+    public let stopStepIdentifier: String?
+    
+    /// Whether or not the recorder requires background audio. Default = `false`.
+    ///
+    /// If `true` then background audio can be used to keep the recorder running if the screen is locked
+    /// because of the idle timer turning off the device screen.
+    ///
+    /// If the app uses background audio, then the developer will need to turn `ON` the "Background Modes"
+    /// under the "Capabilities" tab of the Xcode project, and will need to select "Audio, AirPlay, and
+    /// Picture in Picture".
+    ///
+    public var requiresBackgroundAudio: Bool {
+        return _requiresBackgroundAudio ?? false
+    }
+    private let _requiresBackgroundAudio: Bool?
+    
+    /// Default initializer.
+    /// - parameters:
+    ///     - identifier: The configuration identifier.
+    ///     - motionStepIdentifier: Optional identifier for the step that records distance travelled.
+    ///     - startStepIdentifier: An identifier marking the step to start the action. Default = `nil`.
+    ///     - stopStepIdentifier: An identifier marking the step to stop the action.  Default = `nil`.
+    public init(identifier: String, startStepIdentifier: String? = nil, stopStepIdentifier: String? = nil, requiresBackgroundAudio: Bool = false) {
+        self.identifier = identifier
+        self.startStepIdentifier = startStepIdentifier
+        self.stopStepIdentifier = stopStepIdentifier
+        self._requiresBackgroundAudio = requiresBackgroundAudio
+    }
+    
+    /// Returns `location` and `motion` on iOS. Returns an empty set on platforms that do not
+    /// support distance recording.
+    public var permissionTypes: [RSDPermissionType] {
+        #if os(iOS)
+            return [RSDStandardPermissionType.microphone]
+        #else
+            return []
+        #endif
+    }
+    
+    /// Do nothing. No validation is required for this recorder.
+    public func validate() throws {
+    }
+}
+
+extension AudioRecorderConfiguration : SerializableAsyncActionConfiguration {
+}
+
+extension AudioRecorderConfiguration : DocumentableStruct {
+    public static func codingKeys() -> [CodingKey] {
+        return CodingKeys.allCases
+    }
+    
+    public static func isRequired(_ codingKey: CodingKey) -> Bool {
+        guard let key = codingKey as? CodingKeys else { return false }
+        return key == .asyncActionType || key == .identifier
+    }
+    
+    public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
+        guard let key = codingKey as? CodingKeys else {
+            throw DocumentableError.invalidCodingKey(codingKey, "\(codingKey) is not recognized for this class")
+        }
+        switch key {
+        case .asyncActionType:
+            return .init(constValue: RSDAsyncActionType.distance)
+        case .identifier:
+            return .init(propertyType: .primitive(.string))
+        case .startStepIdentifier, .stopStepIdentifier:
+            return .init(propertyType: .primitive(.string))
+        case ._requiresBackgroundAudio:
+            return .init(propertyType: .primitive(.boolean))
+        }
+    }
+    
+    public static func examples() -> [AudioRecorderConfiguration] {
+        let example = AudioRecorderConfiguration(identifier: "microphone", startStepIdentifier: "countdown", stopStepIdentifier: "rest", requiresBackgroundAudio: true)
+        return [example]
+    }
+}

--- a/Research/Research/DataModel/Objects/AsyncActions/RSDAsyncActionType.swift
+++ b/Research/Research/DataModel/Objects/AsyncActions/RSDAsyncActionType.swift
@@ -52,6 +52,7 @@ public final class AsyncActionConfigurationSerializer : IdentifiableInterfaceSer
         let examples: [SerializableAsyncActionConfiguration] = [
             RSDMotionRecorderConfiguration.examples().first!,
             RSDDistanceRecorderConfiguration.examples().first!,
+            AudioRecorderConfiguration.examples().first!,
         ]
         self.examples = examples
     }
@@ -96,8 +97,11 @@ public struct RSDAsyncActionType : RSDFactoryTypeRepresentable, Codable, Hashabl
     /// Defaults to `RSDDistanceRecorderConfiguration`.
     public static let distance: RSDAsyncActionType = "distance"
     
+    /// Defaults to `AudioRecorderConfiguration`.
+    public static let microphone: RSDAsyncActionType = "microphone"
+    
     fileprivate static func allBaseTypes() -> [RSDAsyncActionType] {
-        return [.motion, .distance]
+        return [.motion, .distance, .microphone]
     }
 }
 

--- a/Research/Research/Info-iOS.plist
+++ b/Research/Research/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-macOS.plist
+++ b/Research/Research/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Research/Research/Info-tvOS.plist
+++ b/Research/Research/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-watchOS.plist
+++ b/Research/Research/Info-watchOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Recorders/RSDDataLogger.swift
+++ b/Research/Research/Recorders/RSDDataLogger.swift
@@ -33,10 +33,22 @@
 
 import Foundation
 
+public protocol RSDFileHandle : class {
+    
+    /// A unique identifier for the logger.
+    var identifier: String { get }
+    
+    /// The url to the file.
+    var url: URL { get }
+    
+    /// The content type of the data file (if known).
+    var contentType: String? { get }
+}
+
 /// `RSDDataLogger` is used to write data samples using a custom encoding to a logging file.
 /// - note: This class does **not** use a serial queue to process the samples. It is assumed that the
 /// recorder that is using this file will handle that implementation.
-open class RSDDataLogger {
+open class RSDDataLogger : RSDFileHandle {
     
     /// A unique identifier for the logger.
     public let identifier: String

--- a/Research/Research/Recorders/RSDSampleRecorder.swift
+++ b/Research/Research/Recorders/RSDSampleRecorder.swift
@@ -503,6 +503,13 @@ open class RSDSampleRecorder : NSObject, RSDAsyncAction {
         return (self.configuration as? RSDJSONRecorderConfiguration)?.usesRootDictionary ?? false
     }
     
+    /// Should the log file include step transition markers? Default = `true`
+    /// If `false`, then the a transition between steps will *not* add a marker record.
+    /// - seealso: `instantiateMarker()`
+    open var shouldIncludeMarkers: Bool {
+        true
+    }
+    
     /// instantiate a marker for recording step transitions as well as start and stop points.
     /// The default implementation will instantiate a `RSDRecordMarker`.
     ///
@@ -607,7 +614,11 @@ open class RSDSampleRecorder : NSObject, RSDAsyncAction {
             let stepPath = self.currentStepPath
             
             // Only write to the file if the recorder status indicates that the logging file is open
-            guard self.status >= RSDAsyncActionStatus.starting && self.status <= RSDAsyncActionStatus.running else { return }
+            guard self.shouldIncludeMarkers,
+                self.status >= RSDAsyncActionStatus.starting && self.status <= RSDAsyncActionStatus.running
+                else {
+                    return
+            }
             
             do {
                 for (identifier, dataLogger) in self.loggers {
@@ -632,7 +643,7 @@ open class RSDSampleRecorder : NSObject, RSDAsyncAction {
                 continue
             }
             loggers[identifier] = dataLogger
-            if let logger = dataLogger as? RSDRecordSampleLogger {
+            if let logger = dataLogger as? RSDRecordSampleLogger, self.shouldIncludeMarkers {
                 let marker = instantiateMarker(uptime: self.clock.startUptime, timestamp: 0, date: self.clock.startDate, stepPath: currentStepPath, loggerIdentifier: identifier)
                 try logger.writeSample(marker)
             }

--- a/Research/Research/Recorders/RSDSampleRecorder.swift
+++ b/Research/Research/Recorders/RSDSampleRecorder.swift
@@ -639,6 +639,19 @@ open class RSDSampleRecorder : NSObject, RSDAsyncAction {
         }
     }
     
+    open func instantiateFileResult(for fileHandle: RSDFileHandle) -> RSDFileResult {
+        // The result identifier is the logger identifer without the section identifier prefix
+        let identifier = fileHandle.identifier.hasPrefix(sectionIdentifier) ?
+            String(fileHandle.identifier.dropFirst(sectionIdentifier.count)) : fileHandle.identifier
+        var fileResult = RSDFileResultObject(identifier: identifier)
+        fileResult.startDate = self.startDate
+        fileResult.endDate = Date()
+        fileResult.url = fileHandle.url
+        fileResult.startUptime = self.clock.startSystemUptime
+        fileResult.contentType = fileHandle.contentType
+        return fileResult
+    }
+    
     /// Close log files. This method should be called on the `loggerQueue`.
     private func _stopLogger() throws {
         var error: Error?
@@ -647,12 +660,7 @@ open class RSDSampleRecorder : NSObject, RSDAsyncAction {
                 try logger.close()
                 
                 // Create and add the result
-                var fileResult = RSDFileResultObject(identifier: self.configuration.identifier)
-                fileResult.startDate = self.startDate
-                fileResult.endDate = Date()
-                fileResult.url = logger.url
-                fileResult.startUptime = self.clock.startSystemUptime
-                fileResult.contentType = logger.contentType
+                let fileResult = instantiateFileResult(for: logger)
                 self.appendResults(fileResult)
             }
             catch let err {

--- a/Research/Research/Utilities/RSDClock.swift
+++ b/Research/Research/Utilities/RSDClock.swift
@@ -83,8 +83,8 @@ public class RSDClock {
     }
     
     /// The time interval for how long the step has been running.
-    public func runningDuration() -> TimeInterval {
-        return RSDClock.uptime() - startUptime - pauseCumulation
+    public func runningDuration(for uptime: TimeInterval = RSDClock.uptime()) -> TimeInterval {
+        return uptime - startUptime - pauseCumulation
     }
     
     /// Pause the clock.

--- a/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorder.swift
+++ b/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorder.swift
@@ -36,7 +36,7 @@ import AVFoundation
 
 extension AudioRecorderConfiguration : RSDAsyncActionVendor {
     
-    /// Instantiate a `AudioRecorder`.
+    /// Instantiate an `AudioRecorder`.
     /// - parameter taskViewModel: The current task path to use to initialize the controller.
     /// - returns: A new instance of `AudioRecorder`.
     public func instantiateController(with taskViewModel: RSDPathComponent) -> RSDAsyncAction? {

--- a/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorder.swift
+++ b/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorder.swift
@@ -45,7 +45,7 @@ extension AudioRecorderConfiguration : RSDAsyncActionVendor {
 }
 
 extension Notification.Name {
-    /// Notification name posted by a `AudioRecorder` instance when it is starting. If you intend to
+    /// Notification name posted by an `AudioRecorder` instance when it is starting. If you intend to
     /// listen for this notification in order to shut down passive recorders, you must pass
     /// nil for the operation queue so it gets handled synchronously on the calling queue.
     public static let AudioRecorderWillStart = Notification.Name(rawValue: "AudioRecorderWillStart")
@@ -92,7 +92,7 @@ public class AudioRecorder : RSDSampleRecorder, AVAudioRecorderDelegate {
     private var audioFileHandle: AudioFileHandle?
     private var audioRecorder: AVAudioRecorder?
     
-    /// Override to implement requesting permission to access the participant's motion sensors.
+    /// Override to implement requesting permission to access the participant's microphone.
     override public func requestPermissions(on viewController: Any, _ completion: @escaping RSDAsyncActionCompletionHandler) {
         self.updateStatus(to: .requestingPermission , error: nil)
         AudioRecorderAudioSessionController.shared.startAudioSessionIfNeeded()
@@ -109,7 +109,7 @@ public class AudioRecorder : RSDSampleRecorder, AVAudioRecorderDelegate {
         }
     }
     
-    /// Override to start the motion sensor updates.
+    /// Override to start recording audio.
     override public func startRecorder(_ completion: @escaping ((RSDAsyncActionStatus, Error?) -> Void)) {
         guard self.audioRecorder == nil, self.audioFileHandle == nil else {
             completion(.failed, RecorderError.alreadyRunning)
@@ -160,7 +160,7 @@ public class AudioRecorder : RSDSampleRecorder, AVAudioRecorderDelegate {
         }
     }
 
-    /// Override to stop updating the motion sensors.
+    /// Override to stop recording audio.
     override public func stopRecorder(_ completion: @escaping ((RSDAsyncActionStatus) -> Void)) {
         
         updateStatus(to: .processingResults, error: nil)

--- a/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorder.swift
+++ b/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorder.swift
@@ -1,0 +1,233 @@
+//
+//  AudioRecorder.swift
+//  ResearchAudioRecorder
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+import AVFoundation
+
+extension AudioRecorderConfiguration : RSDAsyncActionVendor {
+    
+    /// Instantiate a `AudioRecorder`.
+    /// - parameter taskViewModel: The current task path to use to initialize the controller.
+    /// - returns: A new instance of `AudioRecorder`.
+    public func instantiateController(with taskViewModel: RSDPathComponent) -> RSDAsyncAction? {
+        return AudioRecorder(configuration: self, taskViewModel: taskViewModel, outputDirectory: taskViewModel.outputDirectory)
+    }
+}
+
+extension Notification.Name {
+    /// Notification name posted by a `AudioRecorder` instance when it is starting. If you intend to
+    /// listen for this notification in order to shut down passive recorders, you must pass
+    /// nil for the operation queue so it gets handled synchronously on the calling queue.
+    public static let AudioRecorderWillStart = Notification.Name(rawValue: "AudioRecorderWillStart")
+}
+
+extension RSDIdentifier {
+    /// Identifier key used to pass a reference to the AudioRecorder instance in the above
+    /// notification's userInfo.
+    public static let audioRecorderInstance: RSDIdentifier = "audioRecorderInstance"
+}
+
+/// `AudioRecorder` is a subclass of `RSDSampleRecorder` that implements recording audio.
+///
+/// You will need to add the privacy permission for using the microphone to the application `Info.plist`
+/// file. As of this writing (syoung 09/02/2020), the required key is:
+/// - `Privacy - Microphone Usage Description`
+///
+/// - note: This recorder is only available on iOS devices.
+///
+/// - seealso: `AudioRecorderConfiguration`.
+public class AudioRecorder : RSDSampleRecorder, AVAudioRecorderDelegate {
+    
+    /// The currently-running instance, if any. You should confirm that this is nil
+    /// (on the main queue) before starting a passive recorder instance.
+    public static var current: AudioRecorder?
+    
+    /// The motion sensor configuration for this recorder.
+    public var audioConfiguration: AudioRecorderConfiguration? {
+        return self.configuration as? AudioRecorderConfiguration
+    }
+    
+    /// The default logger is just a file with markers for each step transition.
+    public override var defaultLoggerIdentifier: String {
+        "\(super.defaultLoggerIdentifier)_markers"
+    }
+    
+    private var audioFileHandle: AudioFileHandle?
+    private var audioRecorder: AVAudioRecorder?
+    
+    /// Override to implement requesting permission to access the participant's motion sensors.
+    override public func requestPermissions(on viewController: Any, _ completion: @escaping RSDAsyncActionCompletionHandler) {
+        self.updateStatus(to: .requestingPermission , error: nil)
+        AudioRecorderAudioSessionController.shared.startAudioSessionIfNeeded()
+        if AudioRecorderAuthorization.authorizationStatus() == .authorized {
+            self.updateStatus(to: .permissionGranted , error: nil)
+            completion(self, nil, nil)
+        } else {
+            AudioRecorderAuthorization.requestAuthorization { [weak self] (authStatus, error) in
+                guard let strongSelf = self else { return }
+                let status: RSDAsyncActionStatus = (authStatus == .authorized) ? .permissionGranted : .failed
+                strongSelf.updateStatus(to: status, error: error)
+                completion(strongSelf, nil, error)
+            }
+        }
+    }
+    
+    /// Override to start the motion sensor updates.
+    override public func startRecorder(_ completion: @escaping ((RSDAsyncActionStatus, Error?) -> Void)) {
+        guard self.audioRecorder == nil, self.audioFileHandle == nil else {
+            completion(.failed, RecorderError.alreadyRunning)
+            return
+        }
+
+        // Tell the world that a new audio recorder instance is running.
+        NotificationCenter.default.post(name: .AudioRecorderWillStart, object: self, userInfo: [RSDIdentifier.audioRecorderInstance: self])
+        
+        // Call completion before starting the recorder then add a block to the main queue
+        // to start the recorder on the next run loop.
+        completion(.running, nil)
+        DispatchQueue.main.async { [weak self] in
+            self?._startNextRunLoop()
+        }
+    }
+    
+    private func _startNextRunLoop() {
+        guard self.status <= .running else { return }
+        AudioRecorder.current = self
+        
+        let settings = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 12000,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+        ]
+        let fileIdentifier = "\(self.sectionIdentifier)\(self.configuration.identifier)"
+        
+        do {
+            let fileHandle = try AudioFileHandle(identifier: fileIdentifier,
+                                                 outputDirectory: outputDirectory)
+            
+            let recorder = try AVAudioRecorder(url: fileHandle.url, settings: settings)
+            recorder.delegate = self
+            recorder.record()
+            
+            self.audioRecorder = recorder
+            self.audioFileHandle = fileHandle
+            
+            // Set up the interruption observer.
+            self.setupInterruptionObserver()
+        }
+        catch let err {
+            self.didFail(with: err)
+        }
+    }
+
+    /// Override to stop updating the motion sensors.
+    override public func stopRecorder(_ completion: @escaping ((RSDAsyncActionStatus) -> Void)) {
+        
+        updateStatus(to: .processingResults, error: nil)
+        
+        DispatchQueue.main.async {
+
+            if let fileHandle = self.audioFileHandle {
+                let result = self.instantiateFileResult(for: fileHandle)
+                self.appendResults(result)
+                self.audioFileHandle = nil
+            }
+            
+            self.updateStatus(to: .stopping, error: nil)
+            
+            self.stopInterruptionObserver()
+            
+            if let recorder = self.audioRecorder {
+                 recorder.stop()
+                 self.audioRecorder = nil
+             }
+
+            if AudioRecorder.current == self {
+                AudioRecorder.current = nil
+            }
+            
+            // and then call finished.
+            completion(.finished)
+        }
+    }
+    
+    // MARK: AVAudioRecorderDelegate
+    
+    public func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+        let err = error ?? RecorderError.interrupted
+        self.didFail(with: err)
+    }
+    
+    // MARK: Phone interruption
+    
+    private var _audioInterruptObserver: Any?
+    
+    func setupInterruptionObserver() {
+        
+        // If the task should cancel if interrupted by a phone call, then set up a listener.
+        _audioInterruptObserver = NotificationCenter.default.addObserver(forName: AVAudioSession.interruptionNotification, object: nil, queue: OperationQueue.main, using: { [weak self] (notification) in
+            guard let rawValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+                let type = AVAudioSession.InterruptionType(rawValue: rawValue), type == .began
+                else {
+                    return
+            }
+
+            // The recorder is not currently designed to handle phone calls and resume. Until
+            // there is a use-case for prioritizing pause/resume of this recorder
+            // (not currently implemented), just stop the recorder. syoung 05/21/2019
+            self?.didFail(with: RecorderError.interrupted)
+        })
+    }
+    
+    func stopInterruptionObserver() {
+        if let observer = _audioInterruptObserver {
+            NotificationCenter.default.removeObserver(observer)
+            _audioInterruptObserver = nil
+        }
+    }
+}
+
+class AudioFileHandle : RSDFileHandle {
+    
+    let identifier: String
+    let url: URL
+    var contentType: String? {
+        "audio/mp4"
+    }
+    
+    init(identifier: String, outputDirectory: URL) throws {
+        self.identifier = identifier
+        self.url = try RSDFileResultUtility.createFileURL(identifier: identifier, ext: "mp4", outputDirectory: outputDirectory, shouldDeletePrevious: false)
+    }
+}

--- a/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderAudioSessionController.swift
+++ b/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderAudioSessionController.swift
@@ -1,0 +1,85 @@
+//
+//  AudioRecorderAudioSessionController.swift
+//  Research
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+import AVFoundation
+
+/// The audio session controller to use when recording audio in the background with the phone
+/// screen locked.
+///
+/// Note: This controller cannot be used to control background audio for a motion sensor task
+/// without *both* this *and* the motion sensor having the same timing. The motion sensor task
+/// works around the phone going to sleep by playing a silent audio clip.
+public final class AudioRecorderAudioSessionController : NSObject, RSDAudioSessionController {
+    
+    static let shared = AudioRecorderAudioSessionController()
+    
+    /// The audio session is a shared pointer to the current audio session (if running). This is used to
+    /// allow background audio. Background audio is required in order for an active step to play sound
+    /// such as voice commands to a participant who make not be looking at their screen.
+    ///
+    /// - note: The application settings will need to include setting capabilities appropriate for
+    /// background audio if this feature is used.
+    ///
+    public private(set) var audioSession: AVAudioSession?
+    
+    /// Start the background audio session if needed. This will look to see if `audioSession` is already started
+    /// and if not, will start a new session.
+    public func startAudioSessionIfNeeded() {
+        guard audioSession == nil else { return }
+        // Start the background audio session
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .default, options: .mixWithOthers)
+            try session.setActive(true)
+            audioSession = session
+        }
+        catch let err {
+            debugPrint("Failed to start AV session. \(err)")
+        }
+    }
+    
+    /// Stop the audio session and audio player.
+    public func stopAudioSession() {
+        
+        // Release the session
+        if audioSession != nil {
+            do {
+                audioSession = nil
+                try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            } catch let err {
+                debugPrint("Failed to stop AV session. \(err)")
+            }
+        }
+    }
+}

--- a/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderAudioSessionController.swift
+++ b/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderAudioSessionController.swift
@@ -46,7 +46,7 @@ public final class AudioRecorderAudioSessionController : NSObject, RSDAudioSessi
     
     /// The audio session is a shared pointer to the current audio session (if running). This is used to
     /// allow background audio. Background audio is required in order for an active step to play sound
-    /// such as voice commands to a participant who make not be looking at their screen.
+    /// such as voice commands to a participant who may not be looking at their screen.
     ///
     /// - note: The application settings will need to include setting capabilities appropriate for
     /// background audio if this feature is used.

--- a/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderAuthorization.swift
+++ b/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderAuthorization.swift
@@ -1,0 +1,89 @@
+//
+//  AudioRecorderAuthorization.swift
+//  ResearchAudioRecorder
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+import AVFoundation
+
+fileprivate let _userDefaultsKey = "rsd_AudioRecorderStatus"
+
+/// `AudioRecorderAuthorization` is a wrapper for requestion permission to record audio.
+///
+/// Before using this adaptor with a permission step, the calling application or framework will need to
+/// register the adaptor using `RSDAuthorizationHandler.registerAdaptorIfNeeded()`.
+///
+/// - seealso: `RSDPermissionsStepViewController`
+public final class AudioRecorderAuthorization : RSDAuthorizationAdaptor {
+    
+    public static let shared = AudioRecorderAuthorization()
+    
+    /// This adaptor is intended for checking for audio recording permission.
+    public let permissions: [RSDPermissionType] = [RSDStandardPermissionType.microphone]
+    
+    /// Returns the authorization status for recording audio.
+    public func authorizationStatus(for permission: String) -> RSDAuthorizationStatus {
+        guard permission == RSDStandardPermissionType.microphone.rawValue else { return .notDetermined }
+        return AudioRecorderAuthorization.authorizationStatus()
+    }
+    
+    static public func authorizationStatus() -> RSDAuthorizationStatus {
+        let status = AVAudioSession.sharedInstance().recordPermission
+        switch status {
+        case .denied:
+            return .denied
+        case .granted:
+            return .authorized
+        default:
+            return .notDetermined
+        }
+    }
+    
+    /// Requests permission to record.
+    public func requestAuthorization(for permission: RSDPermission, _ completion: @escaping ((RSDAuthorizationStatus, Error?) -> Void)) {
+        guard permission.identifier == RSDStandardPermissionType.microphone.rawValue else {
+            completion(.notDetermined, nil)
+            return
+        }
+        return AudioRecorderAuthorization.requestAuthorization(completion)
+    }
+
+    /// Request authorization to record.
+    static public func requestAuthorization(_ completion: @escaping ((RSDAuthorizationStatus, Error?) -> Void)) {
+        AVAudioSession.sharedInstance().requestRecordPermission { granted in
+            if granted {
+                completion(.authorized, nil)
+            } else {
+                completion(.denied, nil)
+            }
+        }
+    }
+}

--- a/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderTaskObject.swift
+++ b/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderTaskObject.swift
@@ -39,7 +39,7 @@ extension RSDTaskType {
 
 /// This is a background task for recording audio in the background. If your task requires *both*
 /// background audio recording and motion sensor data, use this background task rather than
-/// subclassing from `ResearchMotion.RSDMotionTaskObject` since that version will playback a silent
+/// subclassing from `ResearchMotion.RSDMotionTaskObject` since that version will play back a silent
 /// audio file rather than setting up the audio session for playback and recording.
 open class AudioRecorderTaskObject: AssessmentTaskObject, RSDBackgroundTask {
     open override class func defaultType() -> RSDTaskType {

--- a/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderTaskObject.swift
+++ b/Research/ResearchAudioRecorder/Audio Recorder/AudioRecorderTaskObject.swift
@@ -1,0 +1,54 @@
+//
+//  AudioRecorderTaskObject.swift
+//  ResearchAudioRecorder
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+extension RSDTaskType {
+    public static let audioRecorderTask: RSDTaskType = "audioRecorderTask"
+}
+
+/// This is a background task for recording audio in the background. If your task requires *both*
+/// background audio recording and motion sensor data, use this background task rather than
+/// subclassing from `ResearchMotion.RSDMotionTaskObject` since that version will playback a silent
+/// audio file rather than setting up the audio session for playback and recording.
+open class AudioRecorderTaskObject: AssessmentTaskObject, RSDBackgroundTask {
+    open override class func defaultType() -> RSDTaskType {
+        .audioRecorderTask
+    }
+
+    open var shouldEndOnInterrupt: Bool = true
+    
+    open var audioSessionController: RSDAudioSessionController? {
+        AudioRecorderAudioSessionController.shared
+    }
+}

--- a/Research/ResearchAudioRecorder/Info.plist
+++ b/Research/ResearchAudioRecorder/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Research/ResearchAudioRecorder/Info.plist
+++ b/Research/ResearchAudioRecorder/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Research/ResearchAudioRecorder/ResearchAudioRecorder.h
+++ b/Research/ResearchAudioRecorder/ResearchAudioRecorder.h
@@ -1,0 +1,45 @@
+//
+//  ResearchAudioRecorder.h
+//  ResearchAudioRecorder
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+@import UIKit;
+@import Research;
+
+//! Project version number for ResearchAudioRecorder.
+FOUNDATION_EXPORT double ResearchAudioRecorderVersionNumber;
+
+//! Project version string for ResearchAudioRecorder.
+FOUNDATION_EXPORT const unsigned char ResearchAudioRecorderVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <ResearchAudioRecorder/PublicHeader.h>
+
+

--- a/Research/ResearchAudioRecorderTests/Info.plist
+++ b/Research/ResearchAudioRecorderTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Research/ResearchAudioRecorderTests/Info.plist
+++ b/Research/ResearchAudioRecorderTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Research/ResearchAudioRecorderTests/ResearchAudioRecorderTests.swift
+++ b/Research/ResearchAudioRecorderTests/ResearchAudioRecorderTests.swift
@@ -1,0 +1,34 @@
+//
+//  ResearchAudioRecorderTests.swift
+//  ResearchAudioRecorderTests
+//
+//  Created by Shannon Young on 8/31/20.
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+
+import XCTest
+@testable import ResearchAudioRecorder
+
+class ResearchAudioRecorderTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Research/ResearchAudioRecorderTests/ResearchAudioRecorderTests.swift
+++ b/Research/ResearchAudioRecorderTests/ResearchAudioRecorderTests.swift
@@ -2,8 +2,33 @@
 //  ResearchAudioRecorderTests.swift
 //  ResearchAudioRecorderTests
 //
-//  Created by Shannon Young on 8/31/20.
 //  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 import XCTest

--- a/Research/ResearchLocation/Info.plist
+++ b/Research/ResearchLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 </dict>

--- a/Research/ResearchLocationTests/Info.plist
+++ b/Research/ResearchLocationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 </dict>

--- a/Research/ResearchMotion/Info.plist
+++ b/Research/ResearchMotion/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 </dict>

--- a/Research/ResearchMotionTests/Info.plist
+++ b/Research/ResearchMotionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 </dict>

--- a/Research/ResearchTests/Info-iOS.plist
+++ b/Research/ResearchTests/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 </dict>

--- a/Research/ResearchUI/Info-iOS.plist
+++ b/Research/ResearchUI/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 </dict>

--- a/Research/ResearchUITests/Info.plist
+++ b/Research/ResearchUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9</string>
+	<string>3.10</string>
 	<key>CFBundleVersion</key>
 	<string>98</string>
 </dict>


### PR DESCRIPTION
@apratap 

This adds recording background audio and recording meter level. The default is to *not* save the audio file, but the config has a flag for saving to mp4 acc format. (This is a format that is supported by Android)

WRT the "decibel level", the AVAudioRecorder includes measuring "meter level" with a unit of dbFS, which measures between -160 (completely silent) and 0 (as loud as the measuring device can read). Based on a sample size of my iPhone 7 Plus the quietest environment (inside my car) was returning average readings of about -50, the loudest (right next to the speaker playing music at levels set by my hearing-impaired spouse) was reading about -2 average. I would estimate it to be a little quieter than the factory floor where I use to work (about 80 db, if I recall correctly). In essence, it's not a great measure.

I can also look into the algorithm that I used to measure decibel level, but while that algorithm seemed to do better at ignoring white noise (like a fan), it was tailored specifically to measuring background noise that might interfere with a voice recording (such as a television on in the background) rather than percussive noises (like a door slamming) that might distract the participant.

https://en.wikipedia.org/wiki/DBFS