### PR TITLE
Open copy

### DIFF
--- a/RSDCatalog/RSDCatalog/Info.plist
+++ b/RSDCatalog/RSDCatalog/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>94</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/RSDCatalog/RSDCatalogTests/Info.plist
+++ b/RSDCatalog/RSDCatalogTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>94</string>
 </dict>

--- a/RSDCatalog/RSDCatalogUITests/Info.plist
+++ b/RSDCatalog/RSDCatalogUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>94</string>
 </dict>

--- a/Research/ReleaseNotes.md
+++ b/Research/ReleaseNotes.md
@@ -90,3 +90,10 @@ Research framework can be built for other platforms that do not use some version
 not support `FileManager`.
 
 * Move platform context into the ResearchUI framework.
+
+## Version 3.12
+
+No migration should be required.
+
+Added `AbstractTaskObject` that requires implementing the method `copy(with identifier: String)` and
+does *not* implement it as a public final method.

--- a/Research/Research-UnitTest/Info.plist
+++ b/Research/Research-UnitTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/DataModel/Objects/Task/AssessmentTaskObject.swift
+++ b/Research/Research/DataModel/Objects/Task/AssessmentTaskObject.swift
@@ -102,7 +102,7 @@ extension AssessmentTaskObject : SerializableTask {
 }
 
 /// This is an abstract implementation of `RSDTask` that handles much of the default properties
-/// and polymophism.
+/// and polymorphism.
 ///
 /// This class should *not* be instantiated directly. Subclass implementations are required to
 /// override `defaultType()` and `copy(with identifier: String)`.

--- a/Research/Research/Info-iOS.plist
+++ b/Research/Research/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-macOS.plist
+++ b/Research/Research/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Research/Research/Info-tvOS.plist
+++ b/Research/Research/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 	<key>NSPrincipalClass</key>

--- a/Research/Research/Info-watchOS.plist
+++ b/Research/Research/Info-watchOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 	<key>NSPrincipalClass</key>

--- a/Research/ResearchAudioRecorder/Info.plist
+++ b/Research/ResearchAudioRecorder/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 </dict>

--- a/Research/ResearchAudioRecorderTests/Info.plist
+++ b/Research/ResearchAudioRecorderTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 </dict>

--- a/Research/ResearchLocation/Info.plist
+++ b/Research/ResearchLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 </dict>

--- a/Research/ResearchLocationTests/Info.plist
+++ b/Research/ResearchLocationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 </dict>

--- a/Research/ResearchMotion/Info.plist
+++ b/Research/ResearchMotion/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 </dict>

--- a/Research/ResearchMotionTests/Info.plist
+++ b/Research/ResearchMotionTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 </dict>

--- a/Research/ResearchTests/Info-iOS.plist
+++ b/Research/ResearchTests/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 </dict>

--- a/Research/ResearchUI/Info-iOS.plist
+++ b/Research/ResearchUI/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 </dict>

--- a/Research/ResearchUITests/Info.plist
+++ b/Research/ResearchUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11</string>
+	<string>3.12</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 </dict>


### PR DESCRIPTION
@kalperin 

MTB has requested that the copy method on AssessmentTaskObject be opened, but this pattern does not play well with Swift `Self` and is an all or nothing implementation. To accomidate them, I have created an abstract class that requires overriding the copy method.