### PR TITLE
If there is a step view controller, defer to it for the status bar state

### DIFF
--- a/Research/ResearchUI/iOS/RSDTaskViewController.swift
+++ b/Research/ResearchUI/iOS/RSDTaskViewController.swift
@@ -176,6 +176,16 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
         self.modalPresentationStyle = .fullScreen
     }
     
+    // Status bar
+    
+    open override var prefersStatusBarHidden: Bool {
+        self.currentStepViewController?.prefersStatusBarHidden ?? false
+    }
+    
+    open override var preferredStatusBarStyle: UIStatusBarStyle {
+        self.currentStepViewController?.preferredStatusBarStyle ?? .default
+    }
+    
     // MARK: View controller vending
     
     @available(*, unavailable)


### PR DESCRIPTION
@kalperin 

This is a work-around for getting the timing right on calling `self.setNeedsStatusBarAppearanceUpdate()` to update the status bar. In looking at the MTB task view controller, this will resolve the issue of having the root view controller hide the status bar for tasks where the UI/UX calls for doing so. While strictly speaking, calling `self.setNeedsStatusBarAppearanceUpdate()` instead on view will/did appear at the step view controller level is more appropriate, it's also a rather confusing to try and figure out the timing of when to do so. (ie. This is a belt and suspenders)