### PR TITLE
add “abandon assessment” action and process results

### DIFF
--- a/Research/Research.xcodeproj/project.pbxproj
+++ b/Research/Research.xcodeproj/project.pbxproj
@@ -393,6 +393,7 @@
 		FFDDD65025094177003DB15C /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87061A0227390110056F70E /* ResearchUI.framework */; };
 		FFDDD65125094183003DB15C /* Research_UnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F875575620807E2300235078 /* Research_UnitTest.framework */; };
 		FFDDD65225094183003DB15C /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87061A0227390110056F70E /* ResearchUI.framework */; };
+		FFE274FE2575827700FA621A /* RSDResultProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE274FD2575827700FA621A /* RSDResultProcessor.swift */; };
 		FFE39AEA249D3D1D00446A8B /* IdentifiableInterfaceSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE39AE9249D3D1D00446A8B /* IdentifiableInterfaceSerializer.swift */; };
 		FFEA2F5124366C18008695D6 /* ContentNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEA2F5024366C18008695D6 /* ContentNode.swift */; };
 		FFEA2F572436763B008695D6 /* Question.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEA2F562436763B008695D6 /* Question.swift */; };
@@ -935,6 +936,7 @@
 		FFDFF5DB1FC4F9B9009713E8 /* Date+ISO8601.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+ISO8601.swift"; sourceTree = "<group>"; };
 		FFE0DE4B1F86E39F00BB1BDF /* RSDTextFieldOptionsObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTextFieldOptionsObject.swift; sourceTree = "<group>"; };
 		FFE0DE4E1F874A8600BB1BDF /* RSDFormUIStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDFormUIStepObject.swift; sourceTree = "<group>"; };
+		FFE274FD2575827700FA621A /* RSDResultProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDResultProcessor.swift; sourceTree = "<group>"; };
 		FFE39AE9249D3D1D00446A8B /* IdentifiableInterfaceSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableInterfaceSerializer.swift; sourceTree = "<group>"; };
 		FFEA2F5024366C18008695D6 /* ContentNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentNode.swift; sourceTree = "<group>"; };
 		FFEA2F562436763B008695D6 /* Question.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Question.swift; sourceTree = "<group>"; };
@@ -1137,6 +1139,7 @@
 				F82D111E212602A700EA1A33 /* RSDNavigationResult.swift */,
 				F8112E6F2230B4A3005BCC93 /* RSDScoringResult.swift */,
 				F82D111A2125EB2500EA1A33 /* RSDTaskResult.swift */,
+				FFE274FD2575827700FA621A /* RSDResultProcessor.swift */,
 			);
 			path = Results;
 			sourceTree = "<group>";
@@ -3183,6 +3186,7 @@
 				F82D11172125EAF300EA1A33 /* RSDCollectionResult.swift in Sources */,
 				F8BE11212136023A000AAB1E /* RSDDecodableReplacement.swift in Sources */,
 				FF8B54581FCE6CB1006B6937 /* RSDUIActionHandlerObject.swift in Sources */,
+				FFE274FE2575827700FA621A /* RSDResultProcessor.swift in Sources */,
 				FF81E0B5244A4FF90081644B /* RSDTaskInfoObject.swift in Sources */,
 				FF8B53841FCE6C6F006B6937 /* RSDPermissionType.swift in Sources */,
 				FF8B54611FCE6CB8006B6937 /* RSDViewThemeElementObject.swift in Sources */,

--- a/Research/Research/Core/Interfaces/Results/RSDResultProcessor.swift
+++ b/Research/Research/Core/Interfaces/Results/RSDResultProcessor.swift
@@ -1,0 +1,63 @@
+//
+//  RSDResultProcessor.swift
+//  Research (iOS)
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// This is a hook to allow custom post-processing of the results. Typically, it is recommended that
+/// Assessment creators should processs results as a part of navigation, using a custom
+/// `RSDStepViewModel`, or as a part of the archiving process. That said, there was a special request
+/// to include this method call so here it is. This is called when a method is marked as completed
+/// and before the call to handle completed results. syoung 11/25/2020
+///
+/// If you are beginning a new project using these frameworks, I *strongly* recommend against using
+/// this feature. It is *not* used by Sage Bionetworks in our production applications. Consequently,
+/// it is only tested using functional/unit tests and *not* tested by Sage Research in any of our
+/// assessments. In other words, it is provided as-is and it is our recommendation that you unit
+/// test this feature in your own code if you choose to use it. When unit testing, please keep in
+/// mind that *your* assessments may be included by researchers as a part of a larger assessment,
+/// that may include additional questions or instructions for the participant.
+///
+/// Instead, I recommend one of the previously developed paths for mutating the result set:
+///
+/// 1. Implement a custom result that adhers to the `RSDTaskRunResult` protocol and have your
+///    `RSDTask` implementation override `instantiateTaskResult()`. If your implementation is a
+///    class then you can use `didSet` to respond to changes to the result set and/or implement
+///    custom serialization of the result.
+/// 2. Have the `RSDStepNavigator` use the `step(after:with:)` method to append custom processed
+///    results to the task result.
+/// 3. Use a custom implementation of `RSDStepViewModel` to handle final "scoring" and add the
+///    result as appropriate.
+///
+public protocol RSDResultProcessor {
+    func processResults(taskViewModel: RSDTaskViewModel, taskResult: inout RSDTaskResult)
+}

--- a/Research/Research/Core/Presentation/RSDTaskViewModel.swift
+++ b/Research/Research/Core/Presentation/RSDTaskViewModel.swift
@@ -633,7 +633,7 @@ extension RSDTaskViewModel {
     
     private func _abandonAssessment() {
         
-        // Mark as abondoned both with the flag and by adding to the results.
+        // Mark as abandoned both with the flag and by adding to the results.
         self.didAbandon = true
         self.taskResult.appendAsyncResult(with:
                                             AnswerResultObject(identifier: RSDIdentifier.abandonAssessment.rawValue, value: .boolean(true)))
@@ -1044,4 +1044,3 @@ extension RSDTaskViewModel {
         return controllers.count > 0 ? controllers : nil
     }
 }
-

--- a/Research/Research/Core/Presentation/RSDTaskViewModel.swift
+++ b/Research/Research/Core/Presentation/RSDTaskViewModel.swift
@@ -2,7 +2,7 @@
 //  RSDTaskViewModel.swift
 //  Research
 //
-//  Copyright © 2017-2018 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2020 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -32,15 +32,6 @@
 //
 
 import Foundation
-
-/// This is a hook to allow custom post-processing of the results. Typically, it is recommended that
-/// Assessment creators should processs results as a part of navigation, using a custom
-/// `RSDStepViewModel`, or as a part of the archiving process. That said, there was a special request
-/// to include this method call so here it is. This is called when a method is marked as completed
-/// and before the call to handle completed results. syoung 11/25/2020
-public protocol RSDResultProcessor {
-    func processResults(taskViewModel: RSDTaskViewModel, taskResult: inout RSDTaskResult)
-}
 
 /// The TaskViewModel is a base class implementation of the presentation layer for managing a task. It uses
 /// the [Model–view–viewmodel (MVVM)](https://en.wikipedia.org/wiki/Model-view-viewmodel) design pattern to

--- a/Research/Research/Core/Types/RSDIdentifier.swift
+++ b/Research/Research/Core/Types/RSDIdentifier.swift
@@ -46,7 +46,7 @@ public struct RSDIdentifier : RawRepresentable, Codable, Hashable {
     }
     
     enum RestrictedIdentifiers : String, Codable, CaseIterable {
-        case exit, nextSection, nextStep, abbreviatedInstructions, taskRunCount, taskExitReason
+        case exit, nextSection, nextStep, abbreviatedInstructions, taskRunCount, taskExitReason, abandonAssessment
     }
     
     /// Exit the activity.
@@ -63,6 +63,9 @@ public struct RSDIdentifier : RawRepresentable, Codable, Hashable {
     
     /// Identifier for a result that indicates the reason why a task was exited.
     public static let taskExitReason = RestrictedIdentifiers.taskRunCount.identifierValue
+    
+    /// Identifier for a special flag that indicates that the assessment should be abandoned.
+    public static let abandonAssessment = RestrictedIdentifiers.abandonAssessment.identifierValue
     
     public static func allGlobalIdentifiers() -> [RSDIdentifier] {
         return RestrictedIdentifiers.allCases.map { $0.identifierValue }

--- a/Research/Research/Core/Types/RSDUIActionType.swift
+++ b/Research/Research/Core/Types/RSDUIActionType.swift
@@ -62,7 +62,7 @@ public enum RSDUIActionType {
         /// Go back in the navigation to review the instructions.
         case reviewInstructions
         
-        /// Abandon running the Assessment. This is similar to a "cancel" action, but where a
+        /// Abandon running the Assessment. This is similar to a "cancel" action, but where that
         /// action assumes that the participant will "come back and do it later", the "abandon"
         /// action suggests that Assessment should be considered "done" for the purposes of the
         /// protocol.

--- a/Research/Research/Core/Types/RSDUIActionType.swift
+++ b/Research/Research/Core/Types/RSDUIActionType.swift
@@ -61,6 +61,18 @@ public enum RSDUIActionType {
         
         /// Go back in the navigation to review the instructions.
         case reviewInstructions
+        
+        /// Abandon running the Assessment. This is similar to a "cancel" action, but where a
+        /// action assumes that the participant will "come back and do it later", the "abandon"
+        /// action suggests that Assessment should be considered "done" for the purposes of the
+        /// protocol.
+        ///
+        /// While typically, this type of navigation is handled by having the `RSDStepNavigator`
+        /// send the participant down a path where you, perhaps, ask them why they want to quit,
+        /// and then add those screens to the step history, this allows a button callback to
+        /// the `RSDStepViewModel` with no UI/UX for those assessment creators who want to force
+        /// quit without allowing the navigator to influence the results. syoung 11/25/2020
+        case abandonAssessment
     }
     
     /// A custom action on the step. Must be handled by the app.

--- a/Research/Research_UnitTest/NavigationTestObjects.swift
+++ b/Research/Research_UnitTest/NavigationTestObjects.swift
@@ -315,6 +315,7 @@ public class TestTaskController: NSObject, RSDTaskController {
     public var hideLoadingIfNeeded_called = false
     public var handleTaskFailure_calledWith: Error?
     public var handleTaskResultReady_calledWith: RSDTaskViewModel?
+    public var handleTaskResultReady_result: RSDTaskResult?
     public var addAsyncActions_called = false
     public var addAsyncActions_calledWith: [RSDAsyncActionConfiguration]?
     public var startAsyncActions_called = false
@@ -367,6 +368,7 @@ public class TestTaskController: NSObject, RSDTaskController {
     
     public func handleTaskResultReady(with taskViewModel: RSDTaskViewModel) {
         handleTaskResultReady_calledWith = taskViewModel
+        handleTaskResultReady_result = taskViewModel.taskResult
         handleTaskResultReady_completionBlock?()
         handleTaskResultReady_completionBlock = nil
     }


### PR DESCRIPTION
By request by MTB team, added a navigation action specific to
abandoning an assessment and allowing the task and/or navigator to
explicitly conform to a protocol to do post-processing on the results.

The idea behind the “abandonAssessment” action is to allow a button
to be set up to *upload* results and mark the task as finished without
actually finishing the task. This is different from how we tend to do UI/
UX where, for example, a participant may want to skip doing an
assessment and we use the navigator to skip to the end. What they
want is to allow a button push to kill the task *without* consulting the
navigator.

WRT the results post-processing. Again, they didn’t want to have the
navigator process the results when the task was completed or use a
custom task result with it’s own implementation of RSDArchivable.
Instead, they wanted to have a separate call in the taskViewModel
to process and mutate the task result outside of those provided
mechanisms.

In the interest of time and shortened schedules, I decided to just
go ahead and implement it.  ¯\_(ツ)_/¯

@kalperin 

To Use:

```
// Call this in the step view controller instead of exitAndRemoveFromSchedule().
// This will also add a result to the async results and set a flag on the taskViewModel.
// And it will clean up the task, background recorders, etc.

stepViewModel.perform(.navigation(.abandonAssessment))
```

To process results, implement `RSDResultProcessor` on either the navigator or the task.