### PR TITLE
Only pin to JsonModel up to next *minor* revision

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "JsonModel",
                  url: "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
-                 from: "1.1.0"),
+                 "1.1.0"..<"1.2.0"),
     ],
     targets: [
 

--- a/Research/Research.xcodeproj/project.pbxproj
+++ b/Research/Research.xcodeproj/project.pbxproj
@@ -4477,7 +4477,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Sage-Bionetworks/JsonModel-Swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 1.1.0;
 			};
 		};


### PR DESCRIPTION
I am using the minor versioning on JsonModel b/c this set of libraries are more akin
to early Swift versions rather than a fully flushed out versioning. If I were to rev the
major version for every breaking change, it would start to get silly huge. Really,
I’d like to use “beta” but Xcode doesn’t allow for supporting that easily and right
now we still need to support both Carthage and SwiftPM.

FYI:
@dephillipsmichael 
@kalperin 