### PR TITLE
Add wrapper for IndexPath which is not defined for macOS

### DIFF
--- a/Research/Research/Core/Presentation/RSDTableDataSource.swift
+++ b/Research/Research/Core/Presentation/RSDTableDataSource.swift
@@ -33,6 +33,13 @@
 
 import Foundation
 
+#if os(macOS)
+public struct IndexPath : Hashable {
+    let item: Int
+    let section: Int
+}
+#endif
+
 public enum RSDUIRowAnimation : Int {
     case fade, right, left, top, bottom, none, middle, automatic
 }


### PR DESCRIPTION
This change is to allow the Research framework to build on macOS.