### PR TITLE
Expose internal function 

### DIFF
--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -1045,7 +1045,7 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
     /// Stop the timer.
     open func stop() {
         _stopTimer()
-        _stopInterruptionObserver()
+        stopInterruptionObserver()
     }
 
     private func _stopTimer() {
@@ -1156,7 +1156,7 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
         })
     }
     
-    func _stopInterruptionObserver() {
+    public func stopInterruptionObserver() {
         if let observer = _audioInterruptObserver {
             NotificationCenter.default.removeObserver(observer)
             _audioInterruptObserver = nil


### PR DESCRIPTION
@syoung-smallwisdom as discussed, the background audio interruptions were restricting me from running background BLE data recorders.  My solution was to sub-class the RSDActiveStepViewController and call stopInterruptionObserver() at the beginning to make sure they don't kill the task; however, that function was internal to SageResearch. 

Also, I point at stable-2.0 for that project, so hoping I can just make a stable 2.01 or something to work off of.