### PR TITLE
Return factoryBundle if bundlefor identifier not found

### DIFF
--- a/Research/ResearchUI/PlatformContext/Model+Platform/RSDResourceInfo+Platform.swift
+++ b/Research/ResearchUI/PlatformContext/Model+Platform/RSDResourceInfo+Platform.swift
@@ -38,10 +38,6 @@ extension ResourceInfo {
     
     /// The bundle returned for the given `bundleIdentifier` or `factoryBundle` if `nil`.
     public var bundle: Bundle? {
-        guard let identifier = bundleIdentifier
-            else {
-                return self.factoryBundle as? Bundle
-        }
-        return Bundle(identifier: identifier)
+        return bundleIdentifier.flatMap { Bundle(identifier: $0) } ?? (self.factoryBundle as? Bundle)
     }
 }


### PR DESCRIPTION
Discovered that this was failing for Swift PM where the bundle identifiers have changed. *sigh*