### PR TITLE
Moved  `BranchNodeResult` and `AssessmentResult` into JsonModel.

### DIFF
--- a/MigrationNotes/ReleaseNotes.md
+++ b/MigrationNotes/ReleaseNotes.md
@@ -142,3 +142,7 @@ See "MigrationNotes_v4.0.md".
 ## Version 4.1
 
 See "MigrationNotes_v4.1.md". 
+
+## Version 4.4
+
+Moved base implementation for `BranchNodeResult` and `AssessmentResult` into JsonModel.

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "18cb823bf75f24a66e631b2a653fcfa4e532f108",
-          "version": "1.3.6"
+          "revision": "8dec86fd0f7ad38c528b50912071307e50aa3c78",
+          "version": "1.4.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "JsonModel",
                  url: "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
-                 "1.3.5"..<"1.4.0"),
+                 from: "1.4.0"),
         .package(name: "MobilePassiveData",
                  url: "https://github.com/Sage-Bionetworks/MobilePassiveData-SDK.git",
                  from: "1.2.3"),

--- a/Research/Research/Core/Interfaces/Results/Result-KotlinModel.swift
+++ b/Research/Research/Core/Interfaces/Results/Result-KotlinModel.swift
@@ -34,40 +34,23 @@
 import Foundation
 import JsonModel
 
-
-
 /// The `BranchNodeResult` is the result created for a given level of navigation of a node tree.
-public protocol BranchNodeResult : CollectionResult {
-
-    /// The running history of the nodes that were traversed as a part of running an assessment.
-    /// This will only include a subset (section) that is the path defined at this level of the
-    /// overall assessment hierarchy.
-    var stepHistory: [ResultData] { get set }
+public extension BranchNodeResult {
     
     /// The path traversed by this branch. The `nodePath` is specific to the navigation implemented
     /// on iOS and is different from the `path` implementation in the Kotlin-native framework.
-    var nodePath: [String] { get set }
+    var nodePath: [String] {
+        get {
+            self.path.map { $0.identifier }
+        }
+        set {
+            self.path = newValue.map { .init(identifier: $0, direction: .forward) }
+        }
+    }
 }
 
-/// An `AssessmentResult` is the top-level `Result` for an assessment.
-public protocol AssessmentResult : RSDTaskResult {
-
-    /// A unique identifier for this run of the assessment. This property is defined as readwrite
-    /// to allow the controller for the task to set this on the `AssessmentResult` children
-    /// included in this run.
-    var taskRunUUID: UUID { get set }
-
-    /// The `versionString` may be a semantic version, timestamp, or sequential revision integer.
-    var versionString: String? { get }
-    
-    ///  A unique identifier for a Assessment model associated with this result. This is explicitly
-    /// included so that the `identifier` can be associated as per the needs of the developers and
-    /// to allow for changes to the API that are not important to the researcher.
-    var assessmentIdentifier: String? { get }
-    
-    /// A unique identifier for a schema associated with this result. This is explicitly
-    /// included so that the `identifier` can be associated as per the needs of the developers and
-    /// to allow for changes to the API that are not important to the researcher.
-    var schemaIdentifier: String? { get }
+extension AssessmentResultObject : RSDTaskResult {
 }
 
+extension BranchNodeResultObject : RSDTaskResult {
+}

--- a/Research/Research/Core/Interfaces/Results/ResultData+RSDExtensions.swift
+++ b/Research/Research/Core/Interfaces/Results/ResultData+RSDExtensions.swift
@@ -65,24 +65,16 @@ public extension CollectionResult {
     /// - parameter result: The result to add to the input results.
     /// - returns: The previous result or `nil` if there wasn't one.
     @discardableResult
-    mutating func appendInputResults(with result: ResultData) -> ResultData? {
-        var previousResult: ResultData?
-        if let idx = children.firstIndex(where: { $0.identifier == result.identifier }) {
-            previousResult = children.remove(at: idx)
-        }
-        children.append(result)
-        return previousResult
+    func appendInputResults(with result: ResultData) -> ResultData? {
+        insert(result)
     }
     
     /// Remove the result with the given identifier.
     /// - parameter result: The result to remove from the input results.
     /// - returns: The previous result or `nil` if there wasn't one.
     @discardableResult
-    mutating func removeInputResult(with identifier: String) -> ResultData? {
-        guard let idx = children.firstIndex(where: { $0.identifier == identifier }) else {
-            return nil
-        }
-        return children.remove(at: idx)
+    func removeInputResult(with identifier: String) -> ResultData? {
+        remove(with: identifier)
     }
 }
 

--- a/Research/Research/Core/Presentation/RSDTaskViewModel.swift
+++ b/Research/Research/Core/Presentation/RSDTaskViewModel.swift
@@ -126,11 +126,10 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
         guard let parent = parentPath else { return }
         self.dataManager = (parent as? RSDHistoryPathComponent)?.dataManager
         self.previousResults = (parent.taskResult.stepHistory.last(where: { $0.identifier == identifier }) as? RSDTaskResult)?.stepHistory
-        var runResult = self.taskResult as? AssessmentResult
-        if let uuid = (parent.taskResult as? AssessmentResult)?.taskRunUUID {
-            runResult?.taskRunUUID = uuid
+        if let runResult = self.taskResult as? AssessmentResult,
+            let uuid = (parent.taskResult as? AssessmentResult)?.taskRunUUID {
+            runResult.taskRunUUID = uuid
         }
-        self.taskResult = runResult ?? self.taskResult
         if let _ = self.task as? RSDSectionStep {
             self.shouldShowAbbreviatedInstructions = (parentPath as? RSDTaskViewModel)?.shouldShowAbbreviatedInstructions
         }
@@ -484,17 +483,17 @@ open class RSDTaskViewModel : RSDTaskState, RSDTaskPathComponent {
             if task != nil {
                 strongSelf.task = task
                 let previousResult = strongSelf.taskResult
-                var newResult = task!.instantiateTaskResult()
+                let newResult = task!.instantiateTaskResult()
                 if previousResult.asyncResults?.count ?? 0 > 0 {
                     var results = newResult.asyncResults ?? []
                     results.append(contentsOf: previousResult.asyncResults!)
                     newResult.asyncResults = results
                 }
-                var runResult = newResult as? AssessmentResult
-                if let uuid = (previousResult as? AssessmentResult)?.taskRunUUID {
-                    runResult?.taskRunUUID = uuid
+                if let runResult = newResult as? AssessmentResult,
+                    let uuid = (previousResult as? AssessmentResult)?.taskRunUUID {
+                    runResult.taskRunUUID = uuid
                 }
-                strongSelf.taskResult = runResult ?? newResult
+                strongSelf.taskResult = newResult
             }
             else {
                 err = error ?? RSDValidationError.unexpectedNullObject("Fetched a nil task without an associated error")

--- a/Research/Research/DataModel/Objects/Result/RSDCollectionResultObject.swift
+++ b/Research/Research/DataModel/Objects/Result/RSDCollectionResultObject.swift
@@ -36,7 +36,7 @@ import JsonModel
 
 /// `RSDCollectionResultObject` is used include multiple results associated with a single step or async action that
 /// may have more that one result.
-public struct RSDCollectionResultObject : SerializableResultData, CollectionResult, RSDNavigationResult, Codable, RSDCopyWithIdentifier {
+public final class RSDCollectionResultObject : SerializableResultData, CollectionResult, RSDNavigationResult, Codable, RSDCopyWithIdentifier {
     
     /// The identifier associated with the task, step, or asynchronous action.
     public let identifier: String
@@ -155,7 +155,7 @@ extension RSDCollectionResultObject : DocumentableStruct {
     }
     
     public static func examples() -> [RSDCollectionResultObject] {
-        var result = RSDCollectionResultObject(identifier: "formStep")
+        let result = RSDCollectionResultObject(identifier: "formStep")
         result.startDate = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
         result.endDate = result.startDate.addingTimeInterval(5 * 60)
         result.children = AnswerResultObject.examples()

--- a/Research/Research/DataModel/Objects/Result/RSDResultType.swift
+++ b/Research/Research/DataModel/Objects/Result/RSDResultType.swift
@@ -48,6 +48,12 @@ extension SerializableResultType {
     
     // syoung 03/09/2022 Added back in for MobileToolbox
     public static let navigation: SerializableResultType = "navigation"
+    
+    // syoung 03/16/2022 Add in the static value extensions
+    public static let answer: SerializableResultType = "answer"
+    public static let collection: SerializableResultType = "collection"
+    public static let file: SerializableResultType = "file"
+    public static let error: SerializableResultType = "error"
 }
 
 // List of the serialization examples included in this library.

--- a/Research/Research/DataModel/Objects/Result/RSDTaskResultObject.swift
+++ b/Research/Research/DataModel/Objects/Result/RSDTaskResultObject.swift
@@ -36,93 +36,10 @@ import JsonModel
 
 /// `RSDTaskResultObject` is a result associated with a task. This object includes a step history, task run UUID,
 /// schema identifier, and asynchronous results.
-public struct RSDTaskResultObject : SerializableResultData, AssessmentResult, Codable {
-    private enum CodingKeys : String, OrderedEnumCodingKey {
-        case serializableType = "type", identifier, startDate, endDate, assessmentIdentifier, schemaIdentifier, versionString, taskRunUUID, stepHistory, asyncResults, nodePath
-    }
-    public private(set) var serializableType: SerializableResultType = .task
+public final class RSDTaskResultObject : AbstractAssessmentResultObject, SerializableResultData, AssessmentResult, MultiplatformResultData, RSDTaskResult {
     
-    /// The identifier associated with the task, step, or asynchronous action.
-    public let identifier: String
-    public let versionString: String?
-    public let assessmentIdentifier: String?
-    public let schemaIdentifier: String?
-
-    public var startDate: Date = Date()
-    public var endDate: Date = Date()
-    public var taskRunUUID: UUID = UUID()
-    public var stepHistory: [ResultData] = []
-    public var asyncResults: [ResultData]?
-    public var nodePath: [String] = []
-    
-    /// Default initializer for this object.
-    ///
-    /// - parameters:
-    ///     - identifier: The identifier string.
-    ///     - schemaInfo: The schemaInfo associated with this task result. Default = `nil`.
-    public init(identifier: String,
-                versionString: String? = nil,
-                assessmentIdentifier: String? = nil,
-                schemaIdentifier: String? = nil) {
-        self.identifier = identifier
-        self.versionString = versionString
-        self.assessmentIdentifier = assessmentIdentifier
-        self.schemaIdentifier = schemaIdentifier
-    }
-    
-    /// Initialize from a `Decoder`. This decoding method will use the `RSDFactory` instance associated
-    /// with the decoder to decode the `stepHistory`, `asyncResults`, and `schemaInfo`.
-    ///
-    /// - parameter decoder: The decoder to use to decode this instance.
-    /// - throws: `DecodingError`
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.identifier = try container.decode(String.self, forKey: .identifier)
-        self.startDate = try container.decode(Date.self, forKey: .startDate)
-        self.endDate = try container.decode(Date.self, forKey: .endDate)
-        self.taskRunUUID = try container.decode(UUID.self, forKey: .taskRunUUID)
-        self.nodePath = try container.decodeIfPresent([String].self, forKey: .nodePath) ?? []
-        self.versionString = try container.decodeIfPresent(String.self, forKey: .versionString)
-        self.assessmentIdentifier = try container.decodeIfPresent(String.self, forKey: .assessmentIdentifier)
-        self.schemaIdentifier = try container.decodeIfPresent(String.self, forKey: .schemaIdentifier)
-        
-        let resultsContainer = try container.nestedUnkeyedContainer(forKey: .stepHistory)
-        self.stepHistory = try decoder.factory.decodePolymorphicArray(ResultData.self, from: resultsContainer)
-        
-        if container.contains(.asyncResults) {
-            let asyncResultsContainer = try container.nestedUnkeyedContainer(forKey: .asyncResults)
-            self.asyncResults = try decoder.factory.decodePolymorphicArray(ResultData.self, from: asyncResultsContainer)
-        }
-    }
-    
-    /// Encode the result to the given encoder.
-    /// - parameter encoder: The encoder to use to encode this instance.
-    /// - throws: `EncodingError`
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(identifier, forKey: .identifier)
-        try container.encode(serializableType, forKey: .serializableType)
-        try container.encode(startDate, forKey: .startDate)
-        try container.encode(endDate, forKey: .endDate)
-        try container.encode(taskRunUUID, forKey: .taskRunUUID)
-        try container.encode(nodePath, forKey: .nodePath)
-        try container.encodeIfPresent(self.assessmentIdentifier, forKey: .assessmentIdentifier)
-        try container.encodeIfPresent(self.schemaIdentifier, forKey: .schemaIdentifier)
-        try container.encodeIfPresent(self.versionString, forKey: .versionString)
-    
-        var nestedContainer = container.nestedUnkeyedContainer(forKey: .stepHistory)
-        for result in stepHistory {
-            let nestedEncoder = nestedContainer.superEncoder()
-            try result.encode(to: nestedEncoder)
-        }
-        
-        if let results = asyncResults {
-            var asyncContainer = container.nestedUnkeyedContainer(forKey: .asyncResults)
-            for result in results {
-                let nestedEncoder = asyncContainer.superEncoder()
-                try result.encode(to: nestedEncoder)
-            }
-        }
+    public override class func defaultType() -> SerializableResultType {
+        .task
     }
     
     public func deepCopy() -> RSDTaskResultObject {
@@ -142,7 +59,7 @@ public struct RSDTaskResultObject : SerializableResultData, AssessmentResult, Co
 
 extension RSDTaskResultObject : DocumentableRootObject {
     
-    public init() {
+    public convenience init() {
         self.init(identifier: "example")
     }
     
@@ -156,42 +73,7 @@ extension RSDTaskResultObject : DocumentableRootObject {
 }
 
 extension RSDTaskResultObject : DocumentableStruct {
-    public static func codingKeys() -> [CodingKey] {
-        return CodingKeys.allCases
-    }
-    
-    public static func isRequired(_ codingKey: CodingKey) -> Bool {
-        guard let key = codingKey as? CodingKeys else { return false }
-        switch key {
-        case .serializableType, .identifier, .startDate, .endDate, .taskRunUUID, .stepHistory:
-            return true
-        default:
-            return false
-        }
-    }
-    
-    public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
-        guard let key = codingKey as? CodingKeys else {
-            throw DocumentableError.invalidCodingKey(codingKey, "\(codingKey) is not recognized for this class")
-        }
-        switch key {
-        case .serializableType:
-            return .init(constValue: SerializableResultType.task)
-        case .identifier:
-            return .init(propertyType: .primitive(.string))
-        case .assessmentIdentifier, .schemaIdentifier, .versionString:
-            return .init(propertyType: .primitive(.string))
-        case .startDate, .endDate:
-            return .init(propertyType: .format(.dateTime))
-        case .taskRunUUID:
-            return .init(propertyType: .primitive(.string))
-        case .stepHistory, .asyncResults:
-            return .init(propertyType: .interfaceArray("\(ResultData.self)"))
-        case .nodePath:
-            return .init(propertyType: .primitiveArray(.string))
-        }
-    }
-    
+
     public static func examples() -> [RSDTaskResultObject] {
         
         var result = RSDTaskResultObject(identifier: "example")
@@ -199,7 +81,7 @@ extension RSDTaskResultObject : DocumentableStruct {
         var introStepResult = RSDResultObject(identifier: "introduction")
         introStepResult.startDate = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
         introStepResult.endDate = introStepResult.startDate.addingTimeInterval(20)
-        var collectionResult = RSDCollectionResultObject.examples().first!
+        let collectionResult = RSDCollectionResultObject.examples().first!
         collectionResult.startDate = introStepResult.endDate
         collectionResult.endDate = collectionResult.startDate.addingTimeInterval(2 * 60)
         var conclusionStepResult = RSDResultObject(identifier: "conclusion")

--- a/Research/ResearchTests/Codable Tests/CodableResultObjectTests.swift
+++ b/Research/ResearchTests/Codable Tests/CodableResultObjectTests.swift
@@ -86,7 +86,7 @@ class CodableResultObjectTests: XCTestCase {
 
     
     func testStepCollectionResultObject_Codable() {
-        var stepResult = RSDCollectionResultObject(identifier: "foo")
+        let stepResult = RSDCollectionResultObject(identifier: "foo")
         let answerResult1 = AnswerResultObject(identifier: "input1", value: .boolean(true))
         let answerResult2 = AnswerResultObject(identifier: "input2", value: .integer(42))
         stepResult.children = [answerResult1, answerResult2]
@@ -135,7 +135,7 @@ class CodableResultObjectTests: XCTestCase {
     }
     
     func testTaskResultObject_Codable() {
-        var taskResult = RSDTaskResultObject(identifier: "foo",
+        let taskResult = RSDTaskResultObject(identifier: "foo",
                                              versionString: "3",
                                              assessmentIdentifier: "foo 2",
                                              schemaIdentifier: "bar")
@@ -153,7 +153,7 @@ class CodableResultObjectTests: XCTestCase {
             
             XCTAssertEqual(dictionary["identifier"] as? String, "foo")
             XCTAssertNotNil(dictionary["startDate"])
-            XCTAssertNotNil(dictionary["endDate"])
+            XCTAssertNil(dictionary["endDate"])
 
             if let results = dictionary["stepHistory"] as? [[String : Any]] {
                 XCTAssertEqual(results.count, 2)

--- a/Research/ResearchTests/Codable Tests/DataArchiveTests.swift
+++ b/Research/ResearchTests/Codable Tests/DataArchiveTests.swift
@@ -67,7 +67,7 @@ class DataArchiveTests: XCTestCase {
             taskViewModel.taskResult.appendStepHistory(with: AnswerResultObject(identifier: "only", value: .integer(7)))
             
             // add the second collection as a subsection
-            var sectionResult = RSDTaskResultObject(identifier: "sectionA")
+            let sectionResult = RSDTaskResultObject(identifier: "sectionA")
             sectionResult.appendStepHistory(with: RSDResultObject(identifier: "step1"))
             sectionResult.appendStepHistory(with: RSDResultObject(identifier: "step2"))
             sectionResult.appendStepHistory(with: buildCollectionResult(identifier: "collection"))
@@ -148,7 +148,7 @@ class DataArchiveTests: XCTestCase {
             taskViewModel.taskResult.appendStepHistory(with: buildCollectionResult(identifier: "collection"))
             
             // add the second collection as a subsection
-            var sectionResult = RSDTaskResultObject(identifier: "sectionA")
+            let sectionResult = RSDTaskResultObject(identifier: "sectionA")
             sectionResult.appendStepHistory(with: RSDResultObject(identifier: "step1"))
             sectionResult.appendStepHistory(with: RSDResultObject(identifier: "step2"))
             sectionResult.appendStepHistory(with: buildCollectionResult(identifier: "collection"))
@@ -229,7 +229,7 @@ class DataArchiveTests: XCTestCase {
     }
     
     func buildCollectionResult(identifier: String) -> RSDCollectionResultObject {
-        var collectionResult = RSDCollectionResultObject(identifier: identifier)
+        let collectionResult = RSDCollectionResultObject(identifier: identifier)
         for ii in 1...3 {
             collectionResult.appendInputResults(with: AnswerResultObject(identifier: "input\(ii)", value: .integer(ii)))
         }
@@ -237,7 +237,7 @@ class DataArchiveTests: XCTestCase {
     }
     
     func buildSingleAnswerResult(identifier: String, answer: Int) -> RSDCollectionResultObject {
-        var collectionResult = RSDCollectionResultObject(identifier: identifier)
+        let collectionResult = RSDCollectionResultObject(identifier: identifier)
         collectionResult.appendInputResults(with: AnswerResultObject(identifier: identifier, value: .integer(answer)))
         return collectionResult
     }

--- a/Research/ResearchTests/Codable Tests/RecursiveScoreBuilderTests.swift
+++ b/Research/ResearchTests/Codable Tests/RecursiveScoreBuilderTests.swift
@@ -55,27 +55,27 @@ class RecursiveScoreBuilderTests: XCTestCase {
         let score2 = TestResult(identifier: "score2", score: 2, startDate: Date(), endDate: Date())
         let score3 = TestResult(identifier: "score2", score: 3, startDate: Date(), endDate: Date())
         
-        var taskResult = RSDTaskResultObject(identifier: "topLevel")
+        let taskResult = RSDTaskResultObject(identifier: "topLevel")
         
         // Build section A
-        var subResultA = RSDTaskResultObject(identifier: "sectionA")
+        let subResultA = RSDTaskResultObject(identifier: "sectionA")
         subResultA.appendStepHistory(with: RSDResultObject(identifier: "intruction"))
         subResultA.appendStepHistory(with: score1)
         subResultA.appendStepHistory(with: answer1)
-        var collection1 = RSDCollectionResultObject(identifier: "collection")
+        let collection1 = RSDCollectionResultObject(identifier: "collection")
         collection1.appendInputResults(with: answer2)
         collection1.appendInputResults(with: answer3)
         subResultA.appendStepHistory(with: collection1)
         taskResult.appendStepHistory(with: subResultA)
         
         // Build section B
-        var subResultB = RSDTaskResultObject(identifier: "sectionB")
+        let subResultB = RSDTaskResultObject(identifier: "sectionB")
         subResultB.appendStepHistory(with: RSDResultObject(identifier: "intruction"))
         subResultB.appendStepHistory(with: score2)
         taskResult.appendStepHistory(with: subResultB)
         
         // Build section C
-        var subResultC = RSDTaskResultObject(identifier: "sectionC")
+        let subResultC = RSDTaskResultObject(identifier: "sectionC")
         subResultC.appendStepHistory(with: RSDResultObject(identifier: "intruction"))
         subResultC.appendStepHistory(with: score3)
         taskResult.appendStepHistory(with: subResultC)

--- a/Research/ResearchTests/ModelObject Tests/ResultTests.swift
+++ b/Research/ResearchTests/ModelObject Tests/ResultTests.swift
@@ -47,7 +47,7 @@ class ResultTests: XCTestCase {
 
     func testCollectionResultExtensions() {
         
-        var collection = RSDCollectionResultObject(identifier: "test")
+        let collection = RSDCollectionResultObject(identifier: "test")
         let answers = ["a" : 3, "b": 5, "c" : 7]
         answers.forEach {
             let answerResult = AnswerResultObject(identifier: $0.key, value: .integer($0.value))

--- a/Research/ResearchTests/ModelObject Tests/StepViewModelTests.swift
+++ b/Research/ResearchTests/ModelObject Tests/StepViewModelTests.swift
@@ -165,7 +165,7 @@ class StepViewModelTests: XCTestCase {
     func testResultSummaryStepViewModel_String() {
         let resultStep = RSDResultSummaryStepObject(identifier: "feedback", resultIdentifier: "foo")
         let answerResult = AnswerResultObject(identifier: "foo", value: .string("blu"))
-        var taskResult = RSDTaskResultObject(identifier: "magoo")
+        let taskResult = RSDTaskResultObject(identifier: "magoo")
         taskResult.stepHistory = [answerResult]
         let stepViewModel = RSDResultSummaryStepViewModel(step: resultStep, parent: nil)
         stepViewModel.taskResult = taskResult
@@ -178,7 +178,7 @@ class StepViewModelTests: XCTestCase {
     func testResultSummaryStepViewModel_Decimal() {
         let resultStep = RSDResultSummaryStepObject(identifier: "feedback", resultIdentifier: "foo")
         let answerResult = AnswerResultObject(identifier: "foo", value: .number(1.234211))
-        var taskResult = RSDTaskResultObject(identifier: "magoo")
+        let taskResult = RSDTaskResultObject(identifier: "magoo")
         taskResult.stepHistory = [answerResult]
         let stepViewModel = RSDResultSummaryStepViewModel(step: resultStep, parent: nil)
         stepViewModel.taskResult = taskResult
@@ -191,15 +191,15 @@ class StepViewModelTests: XCTestCase {
     func testResultSummaryStepViewModel_Collection() {
         let resultStep = RSDResultSummaryStepObject(identifier: "feedback", resultIdentifier: "foo", unitText: nil, stepResultIdentifier: "step2")
 
-        var result1 = RSDCollectionResultObject(identifier: "step1")
+        let result1 = RSDCollectionResultObject(identifier: "step1")
         let answerResult1 = AnswerResultObject(identifier: "foo", value: .string("magoo"))
         result1.children = [answerResult1, RSDResultObject(identifier: "roo")]
         
-        var result2 = RSDCollectionResultObject(identifier: "step2")
+        let result2 = RSDCollectionResultObject(identifier: "step2")
         let answerResult2 = AnswerResultObject(identifier: "foo", value: .string("blu"))
         result2.children = [answerResult2, RSDResultObject(identifier: "roo")]
         
-        var taskResult = RSDTaskResultObject(identifier: "magoo")
+        let taskResult = RSDTaskResultObject(identifier: "magoo")
         taskResult.stepHistory = [result1, result2]
         
         let stepViewModel = RSDResultSummaryStepViewModel(step: resultStep, parent: nil)

--- a/Research/ResearchTests/Navigation Tests/SurveyRuleTests.swift
+++ b/Research/ResearchTests/Navigation Tests/SurveyRuleTests.swift
@@ -59,7 +59,7 @@ class SurveyRuleTests: XCTestCase {
         let step = MultipleInputQuestionStepObject(identifier: "foo", inputItems: [inputItem1, inputItem2])
         step.actions = [.navigation(.skip) : skipAction]
         
-        var (taskResult, answerResult) = createTaskResult(for: step, with: nil)
+        let (taskResult, answerResult) = createTaskResult(for: step, with: nil)
         let skipResult = RSDResultObject(identifier: answerResult.identifier,
                                          startDate: answerResult.startDate,
                                          endDate: answerResult.endDate,
@@ -83,7 +83,7 @@ class SurveyRuleTests: XCTestCase {
         let step = MultipleInputQuestionStepObject(identifier: "foo", inputItems: [inputItem1, inputItem2])
         step.actions = [.navigation(.skip) : skipAction]
         
-        var (taskResult, answerResult) = createTaskResult(for: step, with: .object(["field1":"boo","field2":3]))
+        let (taskResult, answerResult) = createTaskResult(for: step, with: .object(["field1":"boo","field2":3]))
         let skipResult = RSDResultObject(identifier: answerResult.identifier,
                                          startDate: answerResult.startDate,
                                          endDate: answerResult.endDate,
@@ -101,7 +101,7 @@ class SurveyRuleTests: XCTestCase {
 
         let step = RSDUIStepObject(identifier: "foo")
         
-        var taskResult = RSDTaskResultObject(identifier: "boobaloo")
+        let taskResult = RSDTaskResultObject(identifier: "boobaloo")
         taskResult.appendStepHistory(with: RSDResultObject(identifier: "instruction1"))
         taskResult.appendStepHistory(with: RSDResultObject(identifier: "instruction2"))
         
@@ -1018,7 +1018,7 @@ class SurveyRuleTests: XCTestCase {
     }
     
     func createTaskResult(for step: QuestionStep, with jsonValue: JsonElement?) -> (RSDTaskResultObject, AnswerResultObject) {
-        var taskResult = RSDTaskResultObject(identifier: "boobaloo")
+        let taskResult = RSDTaskResultObject(identifier: "boobaloo")
         taskResult.appendStepHistory(with: RSDResultObject(identifier: "instruction1"))
         taskResult.appendStepHistory(with: RSDResultObject(identifier: "instruction2"))
         

--- a/Research/ResearchTests/Navigation Tests/TaskViewModelTests.swift
+++ b/Research/ResearchTests/Navigation Tests/TaskViewModelTests.swift
@@ -113,7 +113,7 @@ class TaskViewModelTests: XCTestCase {
         var task = TestTask(identifier: "test", stepNavigator: navigator)
         
         // Create an answer result to add to the final task result.
-        var taskResult = RSDTaskResultObject(identifier: "test")
+        let taskResult = RSDTaskResultObject(identifier: "test")
         let answerResultBlu = AnswerResultObject(identifier: "blu", value: .string("goo"))
         taskResult.appendAsyncResult(with: answerResultBlu)
         task.taskResult = taskResult

--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -804,7 +804,7 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
         }
         else {
             // Otherwise, replace the result with a collection result.
-            var collectionResult = RSDCollectionResultObject(identifier: self.step.identifier)
+            let collectionResult = RSDCollectionResultObject(identifier: self.step.identifier)
             collectionResult.appendInputResults(with: previousResult)
             navigationResult = collectionResult
         }


### PR DESCRIPTION
@kalperin 

Because both MobileToolbox and sage surveys are going to be in the same app,
they need to point at a shared dependency tree. Since the timing for MobileToolbox
to migrate to SageResearch 5.0 is *after* this, we will need to keep the result model
serialization in JsonModel for now.

No migration should be required for this change.