### PR TITLE
Deprecate RSDResultObject, SectionResultObject, RSDCollectionResultObject

### DIFF
--- a/Research/Research/Core/Interfaces/Steps/ContentNode.swift
+++ b/Research/Research/Core/Interfaces/Steps/ContentNode.swift
@@ -94,7 +94,7 @@ public extension FormStep {
     func instantiateCollectionResult() -> CollectionResult {
         guard let result = instantiateStepResult() as? CollectionResult else {
             debugPrint("WARNING!!! The instantiated step result does not conform to `CollectionResult`.")
-            return RSDCollectionResultObject(identifier: self.identifier)
+            return CollectionResultObject(identifier: self.identifier)
         }
         return result
     }

--- a/Research/Research/DataModel/Deprecated/RSDCollectionResultObject.swift
+++ b/Research/Research/DataModel/Deprecated/RSDCollectionResultObject.swift
@@ -2,7 +2,7 @@
 //  RSDCollectionResultObject.swift
 //  Research
 //
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2022 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -36,6 +36,7 @@ import JsonModel
 
 /// `RSDCollectionResultObject` is used include multiple results associated with a single step or async action that
 /// may have more that one result.
+@available(*,deprecated, message: "Use `JsonModel.CollectionResultObject` instead.")
 public final class RSDCollectionResultObject : SerializableResultData, CollectionResult, RSDNavigationResult, Codable, RSDCopyWithIdentifier {
     
     /// The identifier associated with the task, step, or asynchronous action.
@@ -121,44 +122,3 @@ public final class RSDCollectionResultObject : SerializableResultData, Collectio
     }
 }
 
-extension RSDCollectionResultObject : DocumentableStruct {
-    public static func codingKeys() -> [CodingKey] {
-        return CodingKeys.allCases
-    }
-    
-    public static func isRequired(_ codingKey: CodingKey) -> Bool {
-        guard let key = codingKey as? CodingKeys else { return false }
-        switch key {
-        case .serializableType, .identifier, .startDate, .children:
-            return true
-        case .skipToIdentifier, .endDate:
-            return false
-        }
-    }
-    
-    public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
-        guard let key = codingKey as? CodingKeys else {
-            throw DocumentableError.invalidCodingKey(codingKey, "\(codingKey) is not recognized for this class")
-        }
-        switch key {
-        case .serializableType:
-            return .init(constValue: SerializableResultType.collection)
-        case .identifier:
-            return .init(propertyType: .primitive(.string))
-        case .startDate, .endDate:
-            return .init(propertyType: .format(.dateTime))
-        case .skipToIdentifier:
-            return .init(propertyType: .primitive(.string))
-        case .children:
-            return .init(propertyType: .interfaceArray("\(ResultData.self)"))
-        }
-    }
-    
-    public static func examples() -> [RSDCollectionResultObject] {
-        let result = RSDCollectionResultObject(identifier: "formStep")
-        result.startDate = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
-        result.endDate = result.startDate.addingTimeInterval(5 * 60)
-        result.children = AnswerResultObject.examples()
-        return [result]
-    }
-}

--- a/Research/Research/DataModel/Deprecated/RSDResultObject.swift
+++ b/Research/Research/DataModel/Deprecated/RSDResultObject.swift
@@ -2,7 +2,7 @@
 //  RSDResultObject.swift
 //  Research
 //
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2022 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -35,6 +35,7 @@ import Foundation
 import JsonModel
 
 /// `RSDResultObject` is a concrete implementation of the base result associated with a task, step, or asynchronous action.
+@available(*,deprecated, message: "Use `JsonModel.ResultObject` instead.")
 public struct RSDResultObject : SerializableResultData, RSDNavigationResult, Codable {
 
     /// The identifier associated with the task, step, or asynchronous action.
@@ -74,41 +75,3 @@ public struct RSDResultObject : SerializableResultData, RSDNavigationResult, Cod
     }
 }
 
-extension RSDResultObject : DocumentableStruct {
-    public static func codingKeys() -> [CodingKey] {
-        return CodingKeys.allCases
-    }
-    
-    public static func isRequired(_ codingKey: CodingKey) -> Bool {
-        guard let key = codingKey as? CodingKeys else { return false }
-        switch key {
-        case .serializableType, .identifier, .startDate, .endDate:
-            return true
-        case .skipToIdentifier:
-            return false
-        }
-    }
-    
-    public static func documentProperty(for codingKey: CodingKey) throws -> DocumentProperty {
-        guard let key = codingKey as? CodingKeys else {
-            throw DocumentableError.invalidCodingKey(codingKey, "\(codingKey) is not recognized for this class")
-        }
-        switch key {
-        case .serializableType:
-            return .init(constValue: SerializableResultType.base)
-        case .identifier:
-            return .init(propertyType: .primitive(.string))
-        case .startDate, .endDate:
-            return .init(propertyType: .format(.dateTime))
-        case .skipToIdentifier:
-            return .init(propertyType: .primitive(.string))
-        }
-    }
-    
-    public static func examples() -> [RSDResultObject] {
-        var result = RSDResultObject(identifier: "step1")
-        result.startDate = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
-        result.endDate = result.startDate.addingTimeInterval(5 * 60)
-        return [result]
-    }
-}

--- a/Research/Research/DataModel/Deprecated/SectionResultObject.swift
+++ b/Research/Research/DataModel/Deprecated/SectionResultObject.swift
@@ -3,7 +3,7 @@
 //  Research
 //
 //
-//  Copyright © 2017-2020 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2022 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -35,6 +35,7 @@
 import Foundation
 import JsonModel
 
+@available(*,deprecated, message: "Use `JsonModel.BranchNodeResultObject` instead.")
 public final class SectionResultObject : AbstractBranchNodeResultObject, SerializableResultData, BranchNodeResult, MultiplatformResultData, RSDTaskResult {
     
     public override class func defaultType() -> SerializableResultType {
@@ -48,35 +49,6 @@ public final class SectionResultObject : AbstractBranchNodeResultObject, Seriali
                             stepHistory: stepHistory.map { $0.deepCopy() },
                             asyncResults: asyncResults?.map { $0.deepCopy() },
                             path: path)
-    }
-}
-
-extension SectionResultObject : DocumentableStruct {
-    
-    public static func examples() -> [SectionResultObject] {
-        
-        var result = SectionResultObject(identifier: "example")
-        
-        var introStepResult = RSDResultObject(identifier: "introduction")
-        introStepResult.startDate = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
-        introStepResult.endDate = introStepResult.startDate.addingTimeInterval(20)
-        let collectionResult = RSDCollectionResultObject.examples().first!
-        collectionResult.startDate = introStepResult.endDate
-        collectionResult.endDate = collectionResult.startDate.addingTimeInterval(2 * 60)
-        var conclusionStepResult = RSDResultObject(identifier: "conclusion")
-        conclusionStepResult.startDate = collectionResult.endDate
-        conclusionStepResult.endDate = conclusionStepResult.startDate.addingTimeInterval(20)
-        result.stepHistory = [introStepResult, collectionResult, conclusionStepResult]
-        
-        var fileResult = FileResultObject.examples().first!
-        fileResult.startDate = collectionResult.startDate
-        fileResult.endDate = collectionResult.endDate
-        result.asyncResults = [fileResult]
-        
-        result.startDate = introStepResult.startDate
-        result.endDate = conclusionStepResult.endDate
-        
-        return [result]
     }
 }
 

--- a/Research/Research/DataModel/Objects/Result/RSDNavigationResultObject.swift
+++ b/Research/Research/DataModel/Objects/Result/RSDNavigationResultObject.swift
@@ -1,8 +1,8 @@
 //
-//  RSDSectionStep.swift
-//  Research
+//  RSDNavigationResultObject.swift
+//  
 //
-//  Copyright © 2017-2018 Sage Bionetworks. All rights reserved.
+//  Copyright © 2022 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -30,46 +30,44 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-
 import Foundation
 import JsonModel
 
+public final class RSDNavigationResultObject : RSDNavigationResult {
 
-/// `RSDSectionStep` is used to define a logical subgrouping of steps such as a section in a longer survey
-/// or an active step that includes an instruction step, countdown step, and activity step.
-public protocol RSDSectionStep: RSDStep, RSDTask, RSDStepNavigator {
+    /// The identifier for the step to go to following this result. If non-nil, then this will be used in
+    /// navigation handling. This property is transient and should not be copied or serialized.
+    public var skipToIdentifier: String?
     
-    /// A list of the steps used to define this subgrouping of steps.
-    var steps: [RSDStep] { get }
+    public private(set) var wrappedResult: ResultData
+    
+    public init(wrappedResult: ResultData) {
+        self.wrappedResult = wrappedResult
+    }
+    
+    public var typeName: String {
+        wrappedResult.typeName
+    }
+    
+    public var identifier: String {
+        wrappedResult.identifier
+    }
+    
+    public var startDate: Date {
+        get { wrappedResult.startDate }
+        set { wrappedResult.startDate = newValue }
+    }
+    
+    public var endDate: Date {
+        get { wrappedResult.endDate }
+        set { wrappedResult.endDate = newValue }
+    }
+    
+    public func deepCopy() -> RSDNavigationResultObject {
+        .init(wrappedResult: wrappedResult.deepCopy())
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        try wrappedResult.encode(to: encoder)
+    }
 }
-
-extension RSDSectionStep {
-    
-    /// Task info is `nil` for a section step.
-    public var taskInfo: RSDTaskInfoStep? {
-        return nil
-    }
-    
-    /// Schema info is `nil` for a section step.
-    public var schemaInfo: RSDSchemaInfo? {
-        return nil
-    }
-    
-    /// The step navigator is `self` for a section step.
-    public var stepNavigator: RSDStepNavigator {
-        return self
-    }
-    
-    /// A section step returns a task result for both the step result and the task result
-    /// This method will throw an assert if the implementation of the section step does not
-    /// return a `RSDTaskResult` as its type.
-    public func instantiateTaskResult() -> RSDTaskResult {
-        let result = self.instantiateStepResult()
-        guard let taskResult = result as? RSDTaskResult else {
-            assertionFailure("Expected that a section step will return a result that conforms to RSDTaskResult protocol.")
-            return BranchNodeResultObject(identifier: identifier)
-        }
-        return taskResult
-    }
-}
-

--- a/Research/Research/DataModel/Objects/Result/RSDResultType.swift
+++ b/Research/Research/DataModel/Objects/Result/RSDResultType.swift
@@ -2,7 +2,7 @@
 //  RSDResultType.swift
 //  Research
 //
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2022 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -33,27 +33,24 @@
 import Foundation
 import JsonModel
 
+
 /// `RSDResultType` is an extendable string enum used by `RSDFactory` to create the appropriate
 /// result type.
 extension SerializableResultType {
 
-    /// Defaults to creating a `RSDResult`.
-    public static let base: SerializableResultType = "base"
-    
     /// Defaults to creating a `RSDTaskResult`.
     public static let task: SerializableResultType = "task"
-    
-    /// Defaults to creating a `SectionResultObject`.
-    public static let section: SerializableResultType = "section"
     
     // syoung 03/09/2022 Added back in for MobileToolbox
     public static let navigation: SerializableResultType = "navigation"
     
-    // syoung 03/16/2022 Add in the static value extensions
-    public static let answer: SerializableResultType = "answer"
-    public static let collection: SerializableResultType = "collection"
-    public static let file: SerializableResultType = "file"
-    public static let error: SerializableResultType = "error"
+    // syoung 05/13/2022 Add in the static value extensions
+    public static let answer: SerializableResultType = SerializableResultType.StandardTypes.answer.resultType
+    public static let base: SerializableResultType = SerializableResultType.StandardTypes.base.resultType
+    public static let collection: SerializableResultType = SerializableResultType.StandardTypes.collection.resultType
+    public static let file: SerializableResultType = SerializableResultType.StandardTypes.file.resultType
+    public static let error: SerializableResultType = SerializableResultType.StandardTypes.error.resultType
+    public static let section: SerializableResultType = SerializableResultType.StandardTypes.section.resultType
 }
 
 // List of the serialization examples included in this library.
@@ -62,9 +59,9 @@ extension ResultDataSerializer {
     func libraryExamples() -> [SerializableResultData] {
         [
             RSDTaskResultObject.examples().first!,
-            SectionResultObject.examples().first!,
-            RSDResultObject.examples().first!,
-            RSDCollectionResultObject.examples().first!,
+            SectionResultObject(identifier: "example"),
+            RSDResultObject(identifier: "example"),
+            RSDCollectionResultObject(identifier: "example"),
         ]
     }
     

--- a/Research/Research/DataModel/Objects/Result/RSDTaskResultObject.swift
+++ b/Research/Research/DataModel/Objects/Result/RSDTaskResultObject.swift
@@ -2,7 +2,7 @@
 //  RSDTaskResultObject.swift
 //  Research
 //
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2022 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -78,13 +78,13 @@ extension RSDTaskResultObject : DocumentableStruct {
         
         var result = RSDTaskResultObject(identifier: "example")
         
-        var introStepResult = RSDResultObject(identifier: "introduction")
+        var introStepResult = ResultObject(identifier: "introduction")
         introStepResult.startDate = ISO8601TimestampFormatter.date(from: "2017-10-16T22:28:09.000-07:00")!
         introStepResult.endDate = introStepResult.startDate.addingTimeInterval(20)
-        let collectionResult = RSDCollectionResultObject.examples().first!
-        collectionResult.startDate = introStepResult.endDate
-        collectionResult.endDate = collectionResult.startDate.addingTimeInterval(2 * 60)
-        var conclusionStepResult = RSDResultObject(identifier: "conclusion")
+        let collectionResult = CollectionResultObject(identifier: "collection")
+        collectionResult.startDateTime = introStepResult.endDate
+        collectionResult.endDateTime = collectionResult.startDate.addingTimeInterval(2 * 60)
+        var conclusionStepResult = ResultObject(identifier: "conclusion")
         conclusionStepResult.startDate = collectionResult.endDate
         conclusionStepResult.endDate = conclusionStepResult.startDate.addingTimeInterval(20)
         result.stepHistory = [introStepResult, collectionResult, conclusionStepResult]

--- a/Research/Research/DataModel/Objects/Step/AbstractUIStepObject.swift
+++ b/Research/Research/DataModel/Objects/Step/AbstractUIStepObject.swift
@@ -123,7 +123,7 @@ open class AbstractUIStepObject : RSDUIActionHandlerObject, RSDDesignableUIStep,
     /// Instantiate a step result that is appropriate for this step. Default implementation will return an `RSDResultObject`.
     /// - returns: A result for this step.
     open func instantiateStepResult() -> ResultData {
-        return RSDResultObject(identifier: identifier)
+        ResultObject(identifier: identifier)
     }
     
     // MARK: validation

--- a/Research/Research/DataModel/Objects/Step/Question/QuestionObjects.swift
+++ b/Research/Research/DataModel/Objects/Step/Question/QuestionObjects.swift
@@ -79,7 +79,7 @@ open class AbstractQuestionStep : RSDUIStepObject, SurveyRuleNavigation, RSDCoho
     /// - returns: A result for this step.
     open override func instantiateStepResult() -> ResultData {
         guard let question = self as? QuestionStep else {
-            return RSDResultObject(identifier: self.identifier)
+            return ResultObject(identifier: self.identifier)
         }
         return AnswerResultObject(identifier: self.identifier,
                                   answerType: question.answerType,

--- a/Research/Research/DataModel/Objects/Step/RSDSectionStepObject.swift
+++ b/Research/Research/DataModel/Objects/Step/RSDSectionStepObject.swift
@@ -71,7 +71,7 @@ public struct RSDSectionStepObject: RSDSectionStep, RSDConditionalStepNavigator,
     /// Instantiate a step result that is appropriate for this step. The default for this struct is a `RSDTaskResultObject`.
     /// - returns: A result for this step.
     public func instantiateStepResult() -> ResultData {
-        return SectionResultObject(identifier: identifier)
+        return BranchNodeResultObject(identifier: identifier)
     }
     
     /// Validate the steps in this section. The steps are valid if their identifiers are unique and if each step is valid.

--- a/Research/Research/DataModel/Objects/Step/RSDStepTransformerObject.swift
+++ b/Research/Research/DataModel/Objects/Step/RSDStepTransformerObject.swift
@@ -133,7 +133,7 @@ fileprivate struct _StepDecoder: Decodable {
 fileprivate struct PlaceholderStep: RSDStep {
     let identifier: String
     let stepType: RSDStepType = "placeholder"
-    func instantiateStepResult() -> ResultData { RSDResultObject(identifier: identifier) }
+    func instantiateStepResult() -> ResultData { ResultObject(identifier: identifier) }
     func validate() throws { }
 }
 

--- a/Research/Research/DataModel/Objects/Step/RSDUIStepObject.swift
+++ b/Research/Research/DataModel/Objects/Step/RSDUIStepObject.swift
@@ -226,7 +226,7 @@ open class RSDUIStepObject : RSDUIActionHandlerObject, RSDDesignableUIStep, RSDT
     /// Instantiate a step result that is appropriate for this step. Default implementation will return a `RSDResultObject`.
     /// - returns: A result for this step.
     open func instantiateStepResult() -> ResultData {
-        return RSDResultObject(identifier: identifier)
+        ResultObject(identifier: identifier)
     }
     
     // MARK: validation

--- a/Research/Research/DataModel/RSDDocumentable.swift
+++ b/Research/Research/DataModel/RSDDocumentable.swift
@@ -66,11 +66,9 @@ public struct RSDDocumentCreator {
     let allCodableObjects: [DocumentableObject.Type] = [
         RSDAnimatedImageThemeElementObject.self,
         RSDCohortNavigationRuleObject.self,
-        RSDCollectionResultObject.self,
         RSDDateRangeObject.self,
         RSDNavigationUIActionObject.self,
         RSDResourceTransformerObject.self,
-        RSDResultObject.self,
         RSDTaskInfoStepObject.self,
         RSDTaskResultObject.self,
         RSDUIActionObject.self,

--- a/Research/ResearchTests/Codable Tests/CodableResultObjectTests.swift
+++ b/Research/ResearchTests/Codable Tests/CodableResultObjectTests.swift
@@ -61,7 +61,7 @@ class CodableResultObjectTests: XCTestCase {
         
         do {
             
-            let object = try decoder.decode(RSDResultObject.self, from: json)
+            let object = try decoder.decode(ResultObject.self, from: json)
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.serializableType, .base)
@@ -86,9 +86,10 @@ class CodableResultObjectTests: XCTestCase {
 
     
     func testStepCollectionResultObject_Codable() {
-        let stepResult = RSDCollectionResultObject(identifier: "foo")
+        let stepResult = CollectionResultObject(identifier: "foo")
         let answerResult1 = AnswerResultObject(identifier: "input1", value: .boolean(true))
         let answerResult2 = AnswerResultObject(identifier: "input2", value: .integer(42))
+        stepResult.endDateTime = Date() // Set an end time (can be nil)
         stepResult.children = [answerResult1, answerResult2]
         
         do {
@@ -111,7 +112,7 @@ class CodableResultObjectTests: XCTestCase {
                 XCTFail("Failed to encode the input results.")
             }
             
-            let object = try decoder.decode(RSDCollectionResultObject.self, from: jsonData)
+            let object = try decoder.decode(CollectionResultObject.self, from: jsonData)
             
             XCTAssertEqual(object.identifier, stepResult.identifier)
             XCTAssertEqual(object.startDate.timeIntervalSinceNow, stepResult.startDate.timeIntervalSinceNow, accuracy: 1)

--- a/Research/ResearchTests/Codable Tests/DataArchiveTests.swift
+++ b/Research/ResearchTests/Codable Tests/DataArchiveTests.swift
@@ -60,16 +60,16 @@ class DataArchiveTests: XCTestCase {
             XCTAssertTrue(FileManager.default.fileExists(atPath: outputDir.path))
             
             // add the first collection to the task path
-            taskViewModel.taskResult.appendStepHistory(with: RSDResultObject(identifier: "step1"))
-            taskViewModel.taskResult.appendStepHistory(with: RSDResultObject(identifier: "step2"))
+            taskViewModel.taskResult.appendStepHistory(with: ResultObject(identifier: "step1"))
+            taskViewModel.taskResult.appendStepHistory(with: ResultObject(identifier: "step2"))
             taskViewModel.taskResult.appendStepHistory(with: buildCollectionResult(identifier: "collection"))
             taskViewModel.taskResult.appendStepHistory(with: buildSingleAnswerResult(identifier: "single", answer: 5))
             taskViewModel.taskResult.appendStepHistory(with: AnswerResultObject(identifier: "only", value: .integer(7)))
             
             // add the second collection as a subsection
             let sectionResult = RSDTaskResultObject(identifier: "sectionA")
-            sectionResult.appendStepHistory(with: RSDResultObject(identifier: "step1"))
-            sectionResult.appendStepHistory(with: RSDResultObject(identifier: "step2"))
+            sectionResult.appendStepHistory(with: ResultObject(identifier: "step1"))
+            sectionResult.appendStepHistory(with: ResultObject(identifier: "step2"))
             sectionResult.appendStepHistory(with: buildCollectionResult(identifier: "collection"))
             sectionResult.appendStepHistory(with: buildSingleAnswerResult(identifier: "single", answer: 3))
             sectionResult.appendStepHistory(with: AnswerResultObject(identifier: "only", value: .integer(9)))
@@ -143,14 +143,14 @@ class DataArchiveTests: XCTestCase {
             XCTAssertTrue(FileManager.default.fileExists(atPath: outputDir.path))
             
             // add the first collection to the task path
-            taskViewModel.taskResult.appendStepHistory(with: RSDResultObject(identifier: "step1"))
-            taskViewModel.taskResult.appendStepHistory(with: RSDResultObject(identifier: "step2"))
+            taskViewModel.taskResult.appendStepHistory(with: ResultObject(identifier: "step1"))
+            taskViewModel.taskResult.appendStepHistory(with: ResultObject(identifier: "step2"))
             taskViewModel.taskResult.appendStepHistory(with: buildCollectionResult(identifier: "collection"))
             
             // add the second collection as a subsection
             let sectionResult = RSDTaskResultObject(identifier: "sectionA")
-            sectionResult.appendStepHistory(with: RSDResultObject(identifier: "step1"))
-            sectionResult.appendStepHistory(with: RSDResultObject(identifier: "step2"))
+            sectionResult.appendStepHistory(with: ResultObject(identifier: "step1"))
+            sectionResult.appendStepHistory(with: ResultObject(identifier: "step2"))
             sectionResult.appendStepHistory(with: buildCollectionResult(identifier: "collection"))
             taskViewModel.taskResult.appendStepHistory(with: sectionResult)
             
@@ -228,16 +228,16 @@ class DataArchiveTests: XCTestCase {
         return FileResultObject(identifier: identifier, url: url, contentType: "text/plain")
     }
     
-    func buildCollectionResult(identifier: String) -> RSDCollectionResultObject {
-        let collectionResult = RSDCollectionResultObject(identifier: identifier)
+    func buildCollectionResult(identifier: String) -> CollectionResultObject {
+        let collectionResult = CollectionResultObject(identifier: identifier)
         for ii in 1...3 {
             collectionResult.appendInputResults(with: AnswerResultObject(identifier: "input\(ii)", value: .integer(ii)))
         }
         return collectionResult
     }
     
-    func buildSingleAnswerResult(identifier: String, answer: Int) -> RSDCollectionResultObject {
-        let collectionResult = RSDCollectionResultObject(identifier: identifier)
+    func buildSingleAnswerResult(identifier: String, answer: Int) -> CollectionResultObject {
+        let collectionResult = CollectionResultObject(identifier: identifier)
         collectionResult.appendInputResults(with: AnswerResultObject(identifier: identifier, value: .integer(answer)))
         return collectionResult
     }

--- a/Research/ResearchTests/Codable Tests/JsonDocumentableTests.swift
+++ b/Research/ResearchTests/Codable Tests/JsonDocumentableTests.swift
@@ -70,8 +70,6 @@ class JsonDocumentableTests: XCTestCase {
                                                 using: factory, protocolType: RSDImageThemeElement.self))
         XCTAssertTrue(checkPolymorphicExamples(for: factory.inputItemSerializer.examples,
                                                 using: factory, protocolType: InputItemBuilder.self))
-        XCTAssertTrue(checkPolymorphicExamples(for: factory.resultSerializer.examples,
-                                                using: factory, protocolType: ResultData.self))
         XCTAssertTrue(checkPolymorphicExamples(for: factory.resultNodeSerializer.examples,
                                                 using: factory, protocolType: ResultNode.self))
         XCTAssertTrue(checkPolymorphicExamples(for: factory.stepSerializer.examples,

--- a/Research/ResearchTests/Codable Tests/RecursiveScoreBuilderTests.swift
+++ b/Research/ResearchTests/Codable Tests/RecursiveScoreBuilderTests.swift
@@ -59,10 +59,10 @@ class RecursiveScoreBuilderTests: XCTestCase {
         
         // Build section A
         let subResultA = RSDTaskResultObject(identifier: "sectionA")
-        subResultA.appendStepHistory(with: RSDResultObject(identifier: "intruction"))
+        subResultA.appendStepHistory(with: ResultObject(identifier: "intruction"))
         subResultA.appendStepHistory(with: score1)
         subResultA.appendStepHistory(with: answer1)
-        let collection1 = RSDCollectionResultObject(identifier: "collection")
+        let collection1 = CollectionResultObject(identifier: "collection")
         collection1.appendInputResults(with: answer2)
         collection1.appendInputResults(with: answer3)
         subResultA.appendStepHistory(with: collection1)
@@ -70,13 +70,13 @@ class RecursiveScoreBuilderTests: XCTestCase {
         
         // Build section B
         let subResultB = RSDTaskResultObject(identifier: "sectionB")
-        subResultB.appendStepHistory(with: RSDResultObject(identifier: "intruction"))
+        subResultB.appendStepHistory(with: ResultObject(identifier: "intruction"))
         subResultB.appendStepHistory(with: score2)
         taskResult.appendStepHistory(with: subResultB)
         
         // Build section C
         let subResultC = RSDTaskResultObject(identifier: "sectionC")
-        subResultC.appendStepHistory(with: RSDResultObject(identifier: "intruction"))
+        subResultC.appendStepHistory(with: ResultObject(identifier: "intruction"))
         subResultC.appendStepHistory(with: score3)
         taskResult.appendStepHistory(with: subResultC)
         

--- a/Research/ResearchTests/ModelObject Tests/ResultTests.swift
+++ b/Research/ResearchTests/ModelObject Tests/ResultTests.swift
@@ -47,7 +47,7 @@ class ResultTests: XCTestCase {
 
     func testCollectionResultExtensions() {
         
-        let collection = RSDCollectionResultObject(identifier: "test")
+        let collection = CollectionResultObject(identifier: "test")
         let answers = ["a" : 3, "b": 5, "c" : 7]
         answers.forEach {
             let answerResult = AnswerResultObject(identifier: $0.key, value: .integer($0.value))

--- a/Research/ResearchTests/ModelObject Tests/StepViewModelTests.swift
+++ b/Research/ResearchTests/ModelObject Tests/StepViewModelTests.swift
@@ -158,8 +158,8 @@ class StepViewModelTests: XCTestCase {
         stepXModel = RSDStepViewModel(step: stepX, parent: sectionA)
         sectionA.currentChild = stepXModel
         
-        top.taskResult.stepHistory = [RSDResultObject(identifier: "step1"),
-                                      RSDResultObject(identifier: "step2")]
+        top.taskResult.stepHistory = [ResultObject(identifier: "step1"),
+                                      ResultObject(identifier: "step2")]
     }
     
     func testResultSummaryStepViewModel_String() {
@@ -191,13 +191,13 @@ class StepViewModelTests: XCTestCase {
     func testResultSummaryStepViewModel_Collection() {
         let resultStep = RSDResultSummaryStepObject(identifier: "feedback", resultIdentifier: "foo", unitText: nil, stepResultIdentifier: "step2")
 
-        let result1 = RSDCollectionResultObject(identifier: "step1")
+        let result1 = CollectionResultObject(identifier: "step1")
         let answerResult1 = AnswerResultObject(identifier: "foo", value: .string("magoo"))
-        result1.children = [answerResult1, RSDResultObject(identifier: "roo")]
+        result1.children = [answerResult1, ResultObject(identifier: "roo")]
         
-        let result2 = RSDCollectionResultObject(identifier: "step2")
+        let result2 = CollectionResultObject(identifier: "step2")
         let answerResult2 = AnswerResultObject(identifier: "foo", value: .string("blu"))
-        result2.children = [answerResult2, RSDResultObject(identifier: "roo")]
+        result2.children = [answerResult2, ResultObject(identifier: "roo")]
         
         let taskResult = RSDTaskResultObject(identifier: "magoo")
         taskResult.stepHistory = [result1, result2]

--- a/Research/ResearchTests/Navigation Tests/SurveyRuleTests.swift
+++ b/Research/ResearchTests/Navigation Tests/SurveyRuleTests.swift
@@ -60,10 +60,10 @@ class SurveyRuleTests: XCTestCase {
         step.actions = [.navigation(.skip) : skipAction]
         
         let (taskResult, answerResult) = createTaskResult(for: step, with: nil)
-        let skipResult = RSDResultObject(identifier: answerResult.identifier,
-                                         startDate: answerResult.startDate,
-                                         endDate: answerResult.endDate,
-                                         skipToIdentifier: "bar")
+        let skipResult = RSDNavigationResultObject(wrappedResult: ResultObject(identifier: answerResult.identifier,
+                                                                               startDate: answerResult.startDate,
+                                                                               endDate: answerResult.endDate))
+        skipResult.skipToIdentifier = "bar"
         taskResult.appendStepHistory(with: skipResult)
 
         let peekingIdentifier = step.nextStepIdentifier(with: taskResult, isPeeking: true)
@@ -84,10 +84,10 @@ class SurveyRuleTests: XCTestCase {
         step.actions = [.navigation(.skip) : skipAction]
         
         let (taskResult, answerResult) = createTaskResult(for: step, with: .object(["field1":"boo","field2":3]))
-        let skipResult = RSDResultObject(identifier: answerResult.identifier,
-                                         startDate: answerResult.startDate,
-                                         endDate: answerResult.endDate,
-                                         skipToIdentifier: "bar")
+        let skipResult = RSDNavigationResultObject(wrappedResult: ResultObject(identifier: answerResult.identifier,
+                                                                               startDate: answerResult.startDate,
+                                                                               endDate: answerResult.endDate))
+        skipResult.skipToIdentifier = "bar"
         taskResult.appendStepHistory(with: skipResult)
         
         let peekingIdentifier = step.nextStepIdentifier(with: taskResult, isPeeking: true)
@@ -102,11 +102,12 @@ class SurveyRuleTests: XCTestCase {
         let step = RSDUIStepObject(identifier: "foo")
         
         let taskResult = RSDTaskResultObject(identifier: "boobaloo")
-        taskResult.appendStepHistory(with: RSDResultObject(identifier: "instruction1"))
-        taskResult.appendStepHistory(with: RSDResultObject(identifier: "instruction2"))
+        taskResult.appendStepHistory(with: ResultObject(identifier: "instruction1"))
+        taskResult.appendStepHistory(with: ResultObject(identifier: "instruction2"))
         
-        var stepResult = RSDResultObject(identifier: "foo")
+        let stepResult = RSDNavigationResultObject(wrappedResult: ResultObject(identifier: "foo"))
         stepResult.skipToIdentifier = "bar"
+        
         taskResult.appendStepHistory(with: stepResult)
         
         let peekingIdentifier = step.nextStepIdentifier(with: taskResult, isPeeking: true)
@@ -1019,8 +1020,8 @@ class SurveyRuleTests: XCTestCase {
     
     func createTaskResult(for step: QuestionStep, with jsonValue: JsonElement?) -> (RSDTaskResultObject, AnswerResultObject) {
         let taskResult = RSDTaskResultObject(identifier: "boobaloo")
-        taskResult.appendStepHistory(with: RSDResultObject(identifier: "instruction1"))
-        taskResult.appendStepHistory(with: RSDResultObject(identifier: "instruction2"))
+        taskResult.appendStepHistory(with: ResultObject(identifier: "instruction1"))
+        taskResult.appendStepHistory(with: ResultObject(identifier: "instruction2"))
         
         let answerResult = step.instantiateStepResult() as! AnswerResultObject
         taskResult.appendStepHistory(with: answerResult)

--- a/Research/ResearchUI/iOS/RSDStepViewController.swift
+++ b/Research/ResearchUI/iOS/RSDStepViewController.swift
@@ -803,10 +803,8 @@ open class RSDStepViewController : UIViewController, RSDStepController, RSDCance
             navigationResult = navResult
         }
         else {
-            // Otherwise, replace the result with a collection result.
-            let collectionResult = RSDCollectionResultObject(identifier: self.step.identifier)
-            collectionResult.appendInputResults(with: previousResult)
-            navigationResult = collectionResult
+            // Otherwise, wrap the result in a navigation result object.
+            navigationResult = RSDNavigationResultObject(wrappedResult: previousResult)
         }
         navigationResult.skipToIdentifier = skipToIdentifier
         self.stepViewModel!.taskResult.appendStepHistory(with: navigationResult)


### PR DESCRIPTION
Since these objects *replace* the JsonModel objects with the same `typeName`, they lead to an indetermant
serialization where the objects being maintained may not be encoded and decoded to the same object. This
introduces the risk of bugs in the encoding.

I checked this against BridgeApp, MotorControl, and MobileToolbox. 