### PR TITLE
Deprecate support for Bridge Exporter v1 and v2 archiving

### DIFF
--- a/MigrationNotes/MigrationNotes_v4.8.md
+++ b/MigrationNotes/MigrationNotes_v4.8.md
@@ -1,0 +1,37 @@
+#  Migration Steps -> v4.8
+
+**Implement `FileArchivable` directly**
+
+Replace your implementations of `RSDArchivable` with `FileArchivable`.
+
+For example, replace `RSDArchivable` with `FileArchivable` and replace:
+
+```
+    public func buildArchiveData(at stepPath: String?) throws -> (manifest: RSDFileManifest, data: Data)? {
+        let data = try self.jsonEncodedData()
+        let manifest = RSDFileManifest(filename: self.fileName,
+                                       timestamp: Date(),
+                                       contentType: "application/json",
+                                       identifier: self.identifier,
+                                       stepPath: stepPath,
+                                       jsonSchema: jsonSchemaURL)
+        return (manifest, data)
+    }
+```
+
+with:
+
+```
+    public func buildArchivableFileData(at stepPath: String?) throws -> (fileInfo: FileInfo, data: Data)? {
+        let data = try self.jsonEncodedData()
+        let manifest = FileInfo(filename: self.fileName,
+                                timestamp: Date(),
+                                contentType: "application/json",
+                                identifier: self.identifier,
+                                stepPath: stepPath,
+                                jsonSchema: jsonSchemaURL)
+        return (manifest, data)
+    }
+
+```
+

--- a/MigrationNotes/MigrationNotes_v4.9.md
+++ b/MigrationNotes/MigrationNotes_v4.9.md
@@ -1,4 +1,4 @@
-#  Migration Steps -> v4.8
+#  Migration Steps -> v4.9
 
 **Implement `FileArchivable` directly**
 

--- a/MigrationNotes/ReleaseNotes.md
+++ b/MigrationNotes/ReleaseNotes.md
@@ -146,3 +146,15 @@ See "MigrationNotes_v4.1.md".
 ## Version 4.4
 
 Moved base implementation for `BranchNodeResult` and `AssessmentResult` into JsonModel.
+
+## Version 4.6
+
+Update Swift Package min target and all app min target OS to iOS 14 and macOS 11.
+
+## Version 4.7
+
+Deprecated unused code and added support for `JsonModel 1.6.0..<3.0.0`
+
+## Version 4.9
+
+Deprecated classes and structs used to support Bridge Exporter v1 and v2.

--- a/Research/Research/Core/DataArchiving/RSDDataArchive.swift
+++ b/Research/Research/Core/DataArchiving/RSDDataArchive.swift
@@ -13,6 +13,7 @@ import ResultModel
 /// the results are sent individually. It is the responsibility of the developer who implements this protocol
 /// for their services to ensure that the data is cached (if offline) and to re-attempt upload of the
 /// encrypted results.
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 public protocol RSDDataArchive : AnyObject {
     
     /// A unique identifier for this archive.
@@ -48,20 +49,30 @@ public protocol RSDDataArchive : AnyObject {
 
 /// An archivable result is an object wrapper for results that allows them to be transformed into
 /// data for a zipped archive or service.
-public protocol RSDArchivable {
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
+public protocol RSDArchivable : FileArchivable {
     
     /// Build the archiveable or uploadable data for this result.
     func buildArchiveData(at stepPath: String?) throws -> (manifest: RSDFileManifest, data: Data)?
 }
 
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 extension RSDArchivable {
     
     /// Convenience method for calling `buildArchiveData()` without a step path.
     public func buildArchiveData() throws -> (manifest: RSDFileManifest, data: Data)? {
         return try self.buildArchiveData(at: nil)
     }
+    
+    /// Implement the newer protocol that is not dependent on SageResearch.
+    public func buildArchivableFileData(at stepPath: String?) throws -> (fileInfo: FileInfo, data: Data)? {
+        try self.buildArchiveData(at: stepPath).map {
+            (.init(from: $0.manifest), $0.data)
+        }
+    }
 }
 
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 internal class TaskArchiver : NSObject {
     
     let manager: RSDDataArchiveManager

--- a/Research/Research/Core/DataArchiving/RSDDataArchiveManager.swift
+++ b/Research/Research/Core/DataArchiving/RSDDataArchiveManager.swift
@@ -11,9 +11,11 @@ import Foundation
 /// composite protocol of the methods defined using Swift, which are required but can include Swift objects
 /// and methods that conform to Objective-C protocols which allows for optional implementation of the
 /// included methods.
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 public protocol RSDDataArchiveManager : RSDSwiftDataArchiveManager, RSDObjCDataArchiveManager {
 }
 
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 public protocol RSDSwiftDataArchiveManager : NSObjectProtocol {
     
     /// Should the task result archiving be continued if there was an error adding data to the current
@@ -47,6 +49,7 @@ public protocol RSDSwiftDataArchiveManager : NSObjectProtocol {
     
 }
 
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 @objc public protocol RSDObjCDataArchiveManager : NSObjectProtocol {
     
     /// Returns the answer key for a given `RSDAnswerResult` to be included in the answer map. This allows

--- a/Research/Research/Core/DataArchiving/RSDFileManifest.swift
+++ b/Research/Research/Core/DataArchiving/RSDFileManifest.swift
@@ -24,6 +24,7 @@ public enum RSDReservedFilename : String {
 }
 
 /// A manifest for a given file that includes the filename, content type, and creation timestamp.
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 public struct RSDFileManifest : Codable, Hashable, Equatable {
     private enum CodingKeys : String, OrderedEnumCodingKey {
         case filename, timestamp, contentType, identifier, stepPath, jsonSchema, metadata
@@ -86,6 +87,7 @@ public struct RSDFileManifest : Codable, Hashable, Equatable {
     }
 }
 
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 extension RSDFileManifest : DocumentableStruct {
     public static func codingKeys() -> [CodingKey] {
         CodingKeys.allCases
@@ -137,6 +139,7 @@ extension RSDFileManifest : DocumentableStruct {
     }
 }
 
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 extension FileInfo {
     init(from fileManifest: RSDFileManifest) {
         self.init(filename: fileManifest.filename,

--- a/Research/Research/Core/DataArchiving/RSDFileResultUtility.swift
+++ b/Research/Research/Core/DataArchiving/RSDFileResultUtility.swift
@@ -100,6 +100,7 @@ public class RSDFileResultUtility {
     ///
     /// - parameter filename: The name of the file.
     /// - returns: String path for the given file name.
+    @available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
     internal static func fileManifest(for filename: RSDReservedFilename) -> RSDFileManifest {
         let filename = (filename.stringValue as NSString).appendingPathExtension("json")!
         return RSDFileManifest(filename: filename, timestamp: Date(), contentType: "application/json")

--- a/Research/Research/Core/DataArchiving/RSDTaskMetadata.swift
+++ b/Research/Research/Core/DataArchiving/RSDTaskMetadata.swift
@@ -9,6 +9,7 @@ import ResultModel
 
 /// The metadata for a task result archive that can be zipped using the app developer's choice of
 /// third-party archival tools.
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 public struct RSDTaskMetadata : Codable, DocumentableRootObject, DocumentableStruct {
     private enum CodingKeys : String, OrderedEnumCodingKey {
         case deviceInfo,

--- a/Research/Research/Core/DataArchiving/RSDTaskState.swift
+++ b/Research/Research/Core/DataArchiving/RSDTaskState.swift
@@ -136,6 +136,7 @@ open class RSDTaskState : NSObject {
     /// The file results will be added to the files list in a JSON serialized file named "metadata.json"
     /// that includes information about the device, application, task, and a file manifest.
     ///
+    @available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
     public func archiveResults(with manager: RSDDataArchiveManager, completion: ((_ error: Error?) -> Void)? = nil) {
         fileManagementQueue.async {
             do {

--- a/Research/Research/Core/Interfaces/Results/ResultData+RSDExtensions.swift
+++ b/Research/Research/Core/Interfaces/Results/ResultData+RSDExtensions.swift
@@ -7,24 +7,6 @@ import JsonModel
 import ResultModel
 import Foundation
 
-
-extension FileResultObject : RSDArchivable {
-    
-    /// Build the archiveable or uploadable data for this result.
-    public func buildArchiveData(at stepPath: String?) throws -> (manifest: RSDFileManifest, data: Data)? {
-        let filename = self.relativePath
-        guard let url = self.url else { return nil }
-        let manifest = RSDFileManifest(filename: filename,
-                                       timestamp: self.startDate,
-                                       contentType: self.contentType,
-                                       identifier: self.identifier,
-                                       stepPath: stepPath,
-                                       jsonSchema: self.jsonSchema)
-        let data = try Data(contentsOf: url)
-        return (manifest, data)
-    }
-}
-
 public extension AnswerResult {
     
     var value: Any? {

--- a/Research/ResearchTests/Codable Tests/DataArchiveTests.swift
+++ b/Research/ResearchTests/Codable Tests/DataArchiveTests.swift
@@ -8,6 +8,7 @@ import XCTest
 import JsonModel
 import ResultModel
 
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 class DataArchiveTests: XCTestCase {
     
     override func setUp() {
@@ -216,6 +217,7 @@ class DataArchiveTests: XCTestCase {
     }
 }
 
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 class TestArchiveManager: NSObject, RSDDataArchiveManager {
     
     var dataArchiverFor: [String : TestDataArchive] = [:]
@@ -259,6 +261,7 @@ class TestArchiveManager: NSObject, RSDDataArchiveManager {
     }
 }
 
+@available(*, deprecated, message: "Support for BridgeSDK archive and export is deprecated. Please use BridgeClient and implement `FileArchivable` directly instead of `RSDArchivable`.")
 class TestDataArchive: NSObject, RSDDataArchive {
 
     let identifier: String


### PR DESCRIPTION
@kalperin

By extension, this will also deprecate support for BridgeSDK.