### PR TITLE
Move the orientation lock so that 3rd party assessments can use w/o this library

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "AssessmentModel",
+        "repositoryURL": "https://github.com/Sage-Bionetworks/AssessmentModelKMM.git",
+        "state": {
+          "branch": null,
+          "revision": "345ff22602e119a44815889512bcc524da504300",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "JsonModel",
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,8 @@ let package = Package(
         .package(name: "MobilePassiveData",
                  url: "https://github.com/Sage-Bionetworks/MobilePassiveData-SDK.git",
                  from: "1.4.0"),
+        .package(url: "https://github.com/Sage-Bionetworks/AssessmentModelKMM.git",
+                 from: "1.0.0"),
     ],
     targets: [
 
@@ -64,6 +66,7 @@ let package = Package(
             name: "ResearchUI",
             dependencies: [
                 "Research",
+                .product(name: "AssessmentModelUI", package: "AssessmentModelKMM"),
             ],
             path: "Research/ResearchUI/",
             exclude: ["Info-iOS.plist"],

--- a/Research/ResearchUI/iOS/RSDAppDelegate.swift
+++ b/Research/ResearchUI/iOS/RSDAppDelegate.swift
@@ -6,6 +6,16 @@
 import Foundation
 import UIKit
 import Research
+import SharedMobileUI
+
+/// Call directly in app launch if not inheriting from `RSDAppDelegate`.
+public final class ResearchUI {
+    public static func setup(defaultFactory: RSDFactory = .init()) {
+        RSDFactory.shared = defaultFactory
+        resourceLoader = ResourceLoader()
+        LocalizationBundle.registerDefaultBundlesIfNeeded()
+    }
+}
 
 /// `RSDAppDelegate` is an optional class that can be used as the appDelegate for an application.
 ///
@@ -40,9 +50,7 @@ open class RSDAppDelegate : UIResponder, UIApplicationDelegate, RSDAlertPresente
         // Override point for customization before application launch.
         
         // Set up color palette and factory.
-        RSDFactory.shared = instantiateFactory()
-        resourceLoader = ResourceLoader()
-        LocalizationBundle.registerDefaultBundlesIfNeeded()
+        ResearchUI.setup(defaultFactory: instantiateFactory())
         let colorRules = instantiateColorRules()
         let fontRules = instantiateFontRules()
         if fontRules != nil || colorRules != nil {
@@ -99,197 +107,5 @@ open class RSDAppDelegate : UIResponder, UIApplicationDelegate, RSDAlertPresente
         return .portrait
     }
     
-    @available(*, deprecated, message: "Use `AppOrientationLockUtility.setOrientationLock()` instead.")
-    open var orientationLock: UIInterfaceOrientationMask? {
-        get { AppOrientationLockUtility.orientationLock }
-        set { AppOrientationLockUtility.setOrientationLock(newValue) }
-    }
 }
 
-/// A SwiftUI app doesn't honor the `supportedInterfaceOrientations` property on a UIViewController so this work-around
-/// allows those apps to use the app lock in conjunction with the app-level `supportedInterfaceOrientations` instead.
-open class RSDSwiftUIAppDelegate : RSDAppDelegate {
-    
-    open override func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?) -> Bool {
-        AppOrientationLockUtility.shouldAutorotate = true
-        return super.application(application, willFinishLaunchingWithOptions: launchOptions)
-    }
-    
-    /// - returns: The `orientationLock` or the `defaultOrientationLock` if nil.
-    open func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        return AppOrientationLockUtility.currentOrientationLock
-    }
-}
-
-/// With SwiftUI, the `UIApplication.shared.delegate` returns nil but the delegate can still be set
-/// and still requires using the method
-/// `application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?)`
-/// to set up orientation properly. Overriding `supportedInterfaceOrientations` in the UIViewController is not enough.
-///
-/// syoung 09/28/2021
-public class AppOrientationLockUtility {
-    
-    public static let willChange: Notification.Name = .init(rawValue: "RSDAppOrientationLockUtilityWillChange")
-    public static let didChange: Notification.Name = .init(rawValue: "RSDAppOrientationLockUtilityDidChange")
-    
-    /// The current supported interface orientations.
-    static public var currentOrientationLock: UIInterfaceOrientationMask {
-        orientationLock ?? defaultOrientationLock
-    }
-    
-    /// By default, should the device rotate using forced device rotation when setting the orientation lock?
-    /// For apps that use a Storyboard and view controllers, this shouldn't be necessary b/c the view controllers will
-    /// honor the `UIViewController.supportedInterfaceOrientations` property and the
-    /// `UIViewController.shouldAutorotate`.
-    ///
-    /// As of this writing (syoung 09/30/2021) SwiftUI does not honor that property even when showing a
-    /// view controller. Or more specfically, some OS versions and devices do and some do not. Therefore,
-    /// if using SwiftUI as the main entry to the app, this must be set == `true` to force rotation changes.
-    ///
-    public static var shouldAutorotate: Bool = false
-    
-    /// The default orientation lock if not overridden by setting the `orientationLock` property.
-    ///
-    /// An application that requires the *default* to be either portrait or landscape, while still
-    /// setting the app allowed orientations to allow some view controllers to rotate, must set
-    /// this property to return those orientations only.
-    ///
-    static public var defaultOrientationLock: UIInterfaceOrientationMask = .portrait
-    
-    /// The `orientationLock` property is used to override the default allowed orientations.
-    ///
-    /// - seealso: `defaultOrientationLock`
-    static public private(set) var orientationLock: UIInterfaceOrientationMask?
-    
-    static public func reset() {
-        setOrientationLock(nil)
-    }
-    
-    /// Set the orientation lock.
-    static public func setOrientationLock(_ newValue: UIInterfaceOrientationMask?, rotateIfNeeded: Bool = shouldAutorotate) {
-        guard newValue != orientationLock else { return }
-        
-        NotificationCenter.default.post(name: Self.willChange, object: self)
-        
-        orientationLock = newValue
-       
-        if rotateIfNeeded {
-            rotate()
-        }
-        
-        NotificationCenter.default.post(name: Self.didChange, object: self)
-    }
-    
-    static func rotate() {
-        guard let windowScene = UIApplication.shared.firstWindowScene else {
-            return
-        }
-        
-        // iOS 16 will throw a warning if you directly attempt to rotate the device.
-        if #available(iOS 16.0, *) {
-            windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: currentOrientationLock))
-            return
-        }
-        
-        // else fallback to shoehorning in the device rotation.
-
-        // Get initial orientation
-        let device = UIDevice.current
-        var orientation = UIDeviceOrientation(rawValue: windowScene.interfaceOrientation.rawValue) ?? device.orientation
-        
-        // Compare current to desired.
-        switch currentOrientationLock {
-        case .portrait:
-            orientation = .portrait
-        case .landscapeLeft:
-            orientation = .landscapeLeft
-        case .landscapeRight:
-            orientation = .landscapeRight
-        case .portraitUpsideDown:
-            orientation = .portraitUpsideDown
-        case .landscape:
-            if orientation != .landscapeRight && orientation != .landscapeLeft {
-                orientation = .landscapeRight
-            }
-        default:
-            break
-        }
-        
-        // Set the device orientation and rotate.
-        device.setValue(orientation.rawValue, forKey: "orientation")
-        UIViewController.attemptRotationToDeviceOrientation()
-    }
-}
-
-extension UIApplication {
-    
-    var firstWindowScene: UIWindowScene? {
-        connectedScenes.first(where: { ($0.activationState == .foregroundActive) && ($0 is UIWindowScene) }) as? UIWindowScene
-    }
-}
-
-extension UIInterfaceOrientationMask {
-    func names() -> [String] {
-        let mapping: [String : UIInterfaceOrientationMask] = [
-            "portrait" : .portrait,
-            "landscape" : .landscape
-        ]
-        return mapping.compactMap { self.contains($0.value) ? $0.key : nil }
-    }
-}
-
-extension UIDeviceOrientation {
-    var name: String {
-        switch self {
-        case .portrait:
-            return "portrait"
-        case .landscapeRight:
-            return "landscapeRight"
-        case .landscapeLeft:
-            return "landscapeLeft"
-        case .portraitUpsideDown:
-            return "portraitUpsideDown"
-        case .faceUp:
-            return "faceUp"
-        case .faceDown:
-            return "faceDown"
-
-        default:
-            return "unknown"
-        }
-    }
-}
-
-/// As of this writing, there is no simple way for an application to allow selectively locking
-/// the orientation of the app to portrait, while still allowing *some* view controllers to
-/// require landscape. This is intended as a work around for that limitation. Using this feature
-/// requires the view controller that needs to change the orientation to set the
-/// `orientationLock` in `viewWillAppear` and then clear the lock on `viewDidAppear`.
-/// syoung 08/15/2019
-///
-/// - seealso: `RSDAppDelegate` for an example implementation.
-@available(*, deprecated, message: "Use `AppOrientationLockUtility` instead.")
-public protocol RSDAppOrientationLock : UIApplicationDelegate {
-    
-    /// The default orientation lock if not overridden by setting the `orientationLock` property.
-    var defaultOrientationLock: UIInterfaceOrientationMask { get }
-    
-    /// The `orientationLock` property is used to override the default allowed orientations.
-    ///
-    /// - seealso: `defaultOrientationLock`
-    var orientationLock: UIInterfaceOrientationMask? { get set }
-}
-
-@available(*, deprecated, message: "Use `AppOrientationLockUtility` instead.")
-extension RSDAppOrientationLock {
-    
-    /// Convenience accessor for the appLock for applications where the app delegate implements
-    /// this protocol.
-    public static var appLock: RSDAppOrientationLock? {
-        return UIApplication.shared.delegate as? RSDAppOrientationLock
-    }
-}
-
-@available(*, deprecated, message: "Use `AppOrientationLockUtility` instead.")
-extension RSDAppDelegate : RSDAppOrientationLock {
-}

--- a/Research/ResearchUI/iOS/RSDTaskViewController.swift
+++ b/Research/ResearchUI/iOS/RSDTaskViewController.swift
@@ -9,6 +9,7 @@ import JsonModel
 import ResultModel
 import Research
 import MobilePassiveData
+import SharedMobileUI
 
 /// `RSDPageViewControllerProtocol` allows replacing the `UIPageViewController` in the base class with a different
 /// view controller implementation. It is assumed that the implementation is for a view controller appropriate to

--- a/SageResearch.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SageResearch.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "AssessmentModel",
+        "repositoryURL": "https://github.com/Sage-Bionetworks/AssessmentModelKMM.git",
+        "state": {
+          "branch": null,
+          "revision": "345ff22602e119a44815889512bcc524da504300",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "JsonModel",
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {

--- a/SwiftUITestApp/SwiftUITestApp/SwiftUITestAppApp.swift
+++ b/SwiftUITestApp/SwiftUITestApp/SwiftUITestAppApp.swift
@@ -6,7 +6,7 @@
 import SwiftUI
 import ResearchUI
 
-class AppDelegate: RSDSwiftUIAppDelegate {
+class AppDelegate: RSDAppDelegate {
 }
 
 @main


### PR DESCRIPTION
Included in the optimistic hope that maybe we will continue working with Northwestern. ¯\_(ツ)_/¯ 